### PR TITLE
refactor(convention): make ability to stub file apis provider to official

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurelia/monorepo",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurelia/monorepo",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "workspaces": [
         "packages/kernel",
@@ -127,12 +127,12 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
         "d3-scale-chromatic": "^3.0.0",
         "perf-monitor": "0.6.0"
       },
@@ -145,18 +145,18 @@
       "name": "@examples/doc-example",
       "version": "0.8.0",
       "dependencies": {
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1"
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2"
       },
       "devDependencies": {
-        "@aurelia/vite-plugin": "2.0.0-rc.1",
+        "@aurelia/vite-plugin": "2.0.0-rc.2",
         "typescript": "5.9.2"
       }
     },
@@ -179,12 +179,12 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
         "perf-monitor": "0.6.0"
       },
       "engines": {
@@ -196,15 +196,15 @@
       "name": "@examples/navigation-skeleton",
       "version": "0.8.0",
       "dependencies": {
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
         "bootstrap": "^5.3.3",
         "font-awesome": "^4.6.3"
       },
@@ -274,12 +274,12 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
         "perf-monitor": "0.6.0"
       },
       "engines": {
@@ -292,11 +292,11 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "aurelia": "2.0.0-rc.1",
+        "aurelia": "2.0.0-rc.2",
         "marked": "^4.0.14"
       },
       "devDependencies": {
-        "@aurelia/testing": "2.0.0-rc.1",
+        "@aurelia/testing": "2.0.0-rc.2",
         "@types/mocha": "10.0.0",
         "@types/node": "^20.16.10",
         "css-loader": "^6.7.1",
@@ -321,11 +321,11 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "aurelia": "2.0.0-rc.1",
+        "aurelia": "2.0.0-rc.2",
         "marked": "^4.0.14"
       },
       "devDependencies": {
-        "@aurelia/testing": "2.0.0-rc.1",
+        "@aurelia/testing": "2.0.0-rc.2",
         "@types/mocha": "10.0.0",
         "@types/node": "^20.16.10",
         "css-loader": "^6.7.1",
@@ -427,19 +427,19 @@
       "name": "@examples/router-animation",
       "version": "1.0.0",
       "dependencies": {
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/router-direct": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1"
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/router-direct": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2"
       },
       "devDependencies": {
-        "@aurelia/ts-jest": "2.0.0-rc.1",
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
+        "@aurelia/ts-jest": "2.0.0-rc.2",
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
         "@types/node": "^20.16.10",
         "autoprefixer": "^10.4.5",
         "css-loader": "^6.7.1",
@@ -502,19 +502,19 @@
       "name": "@examples/router-hooks",
       "version": "1.0.0",
       "dependencies": {
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/router-direct": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1"
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/router-direct": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2"
       },
       "devDependencies": {
-        "@aurelia/ts-jest": "2.0.0-rc.1",
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
+        "@aurelia/ts-jest": "2.0.0-rc.2",
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
         "@types/node": "^20.16.10",
         "autoprefixer": "^10.4.5",
         "css-loader": "^6.7.1",
@@ -578,12 +578,12 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
         "perf-monitor": "0.6.0"
       },
       "engines": {
@@ -596,13 +596,13 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/state": "2.0.0-rc.1"
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/state": "2.0.0-rc.2"
       },
       "engines": {
         "node": ">=14.15.0",
@@ -623,6 +623,10 @@
     },
     "node_modules/@__e2e__/12-type-check": {
       "resolved": "packages/__e2e__/12-type-check",
+      "link": true
+    },
+    "node_modules/@__e2e__/14-vite8-decorators": {
+      "resolved": "packages/__e2e__/14-vite8-decorators",
       "link": true
     },
     "node_modules/@__e2e__/15-ts6-webpack-smoke": {
@@ -2493,6 +2497,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4254,7 +4259,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -4785,6 +4790,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@parcel/cache": {
@@ -5933,6 +5948,323 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
+      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-alias": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
@@ -6218,6 +6550,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6231,6 +6564,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6272,6 +6606,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6285,6 +6620,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6312,6 +6648,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6367,6 +6704,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6380,6 +6718,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6421,6 +6760,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6702,6 +7042,15 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
@@ -6711,6 +7060,12 @@
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
+    },
+    "node_modules/@swc/wasm": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.15.47.tgz",
+      "integrity": "sha512-AdcxrBWz13mPnXxzxr5Lkxkgknwi0fAaArdehpYENB/iIds+WEWVcof3FJKfYAPP7TOeCsaSTKFTSsP3/YX7iw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
@@ -12633,6 +12988,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -17601,7 +17957,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -18625,6 +18981,288 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -19616,6 +20254,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -20826,6 +21465,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -21737,7 +22377,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -21889,11 +22528,45 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.29.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.29.1.tgz",
       "integrity": "sha512-RaJ45M/kmJUzSWDs1Nnd5DdV4eerC98idtUOVr6FfKcgxqvjwHmxc5upLF9qZU9EpsVzzhleFahrT3shLuJzIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -21952,7 +22625,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
@@ -22700,6 +23373,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -23479,7 +24153,7 @@
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -23584,7 +24258,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -23663,6 +24337,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -24688,6 +25363,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -24765,6 +25441,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24781,6 +25458,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24797,6 +25475,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24813,6 +25492,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24829,6 +25509,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24845,6 +25526,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24861,6 +25543,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24877,6 +25560,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24893,6 +25577,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24909,6 +25594,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24925,6 +25611,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24941,6 +25628,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24957,6 +25645,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24973,6 +25662,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24989,6 +25679,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25005,6 +25696,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25021,6 +25713,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25037,6 +25730,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25053,6 +25747,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25069,6 +25764,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25085,6 +25781,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25101,6 +25798,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25117,6 +25815,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25133,6 +25832,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25149,6 +25849,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25165,6 +25866,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25178,6 +25880,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25191,6 +25894,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25204,6 +25908,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25217,6 +25922,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25230,6 +25936,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25243,6 +25950,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25256,6 +25964,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25269,6 +25978,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25282,6 +25992,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25295,6 +26006,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25308,6 +26020,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25321,6 +26034,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25334,6 +26048,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25347,6 +26062,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25360,6 +26076,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25373,6 +26090,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25383,6 +26101,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -25424,6 +26143,7 @@
       "version": "4.55.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
       "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -26289,7 +27009,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -26424,20 +27144,20 @@
       "version": "2.0.0-beta.25",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/babel-jest": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/parcel-transformer": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/plugin-conventions": "2.0.0-rc.1",
-        "@aurelia/plugin-gulp": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/testing": "2.0.0-rc.1",
-        "@aurelia/ts-jest": "2.0.0-rc.1",
-        "@aurelia/vite-plugin": "2.0.0-rc.1",
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
+        "@aurelia/babel-jest": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/parcel-transformer": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/plugin-conventions": "2.0.0-rc.2",
+        "@aurelia/plugin-gulp": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/testing": "2.0.0-rc.2",
+        "@aurelia/ts-jest": "2.0.0-rc.2",
+        "@aurelia/vite-plugin": "2.0.0-rc.2",
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
         "@babel/core": "^7.18.2",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.1.0",
@@ -26549,14 +27269,14 @@
     },
     "packages-tooling/babel-jest": {
       "name": "@aurelia/babel-jest",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/plugin-conventions": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/plugin-conventions": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
         "@babel/core": "^7.18.2",
         "babel-jest": "^29.7.0"
       },
@@ -26595,14 +27315,14 @@
     },
     "packages-tooling/parcel-transformer": {
       "name": "@aurelia/parcel-transformer",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/plugin-conventions": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/plugin-conventions": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
         "@parcel/plugin": "^2.11.0",
         "@parcel/source-map": "^2.1.1"
       },
@@ -26641,16 +27361,16 @@
     },
     "packages-tooling/plugin-conventions": {
       "name": "@aurelia/plugin-conventions",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1",
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2",
         "@typescript/typescript6": "^6.0.2",
         "modify-code": "^2.1.3",
         "parse5": "^7.1.2"
@@ -26689,14 +27409,14 @@
     },
     "packages-tooling/plugin-gulp": {
       "name": "@aurelia/plugin-gulp",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/plugin-conventions": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/plugin-conventions": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
         "vinyl": "^2.2.0"
       },
       "devDependencies": {
@@ -26734,14 +27454,14 @@
     },
     "packages-tooling/ts-jest": {
       "name": "@aurelia/ts-jest",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/plugin-conventions": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/plugin-conventions": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
         "ts-jest": "^29.1.2"
       },
       "devDependencies": {
@@ -26779,14 +27499,14 @@
     },
     "packages-tooling/vite-plugin": {
       "name": "@aurelia/vite-plugin",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/plugin-conventions": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/plugin-conventions": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
         "@rollup/pluginutils": "5.0.2",
         "@swc/helpers": "0.5.23",
         "@swc/wasm": "1.15.47",
@@ -26839,6 +27559,18 @@
         "undici-types": "~6.21.0"
       }
     },
+    "packages-tooling/vite-plugin/node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "packages-tooling/vite-plugin/node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -26867,14 +27599,14 @@
     },
     "packages-tooling/webpack-loader": {
       "name": "@aurelia/webpack-loader",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/plugin-conventions": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/plugin-conventions": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
         "loader-utils": "^2.0.0"
       },
       "devDependencies": {
@@ -26916,14 +27648,14 @@
       "version": "2.0.0-beta.25",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2",
         "perf-monitor": "0.6.0"
       },
       "devDependencies": {
@@ -26954,14 +27686,14 @@
       "version": "2.0.0-beta.25",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2",
         "perf-monitor": "0.6.0"
       },
       "devDependencies": {
@@ -26992,11 +27724,11 @@
       "version": "2.0.0-beta.25",
       "license": "MIT",
       "devDependencies": {
-        "@aurelia/validation": "2.0.0-rc.1",
-        "@aurelia/validation-html": "2.0.0-rc.1",
+        "@aurelia/validation": "2.0.0-rc.2",
+        "@aurelia/validation-html": "2.0.0-rc.2",
         "@playwright/test": "1.39.0",
         "@types/node": "^20.16.10",
-        "aurelia": "2.0.0-rc.1",
+        "aurelia": "2.0.0-rc.2",
         "html-loader": "^1.3.2",
         "html-webpack-plugin": "^5.5.0",
         "playwright-watch": "1.3.23",
@@ -27025,15 +27757,15 @@
       "version": "2.0.0-beta.25",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
       },
       "devDependencies": {
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
         "@playwright/test": "1.39.0",
         "@types/node": "^20.16.10",
         "array-flatten": "^3.0.0",
@@ -27064,12 +27796,12 @@
       "version": "2.0.0-beta.25",
       "license": "MIT",
       "dependencies": {
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/router-direct": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/router-direct": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
       },
       "devDependencies": {
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
         "@playwright/test": "1.39.0",
         "@types/node": "^20.16.10",
         "array-flatten": "^3.0.0",
@@ -27096,2104 +27828,15 @@
         "undici-types": "~6.21.0"
       }
     },
-    "packages/__e2e__/15-ts6-webpack-smoke": {
-      "name": "@__e2e__/15-ts6-webpack-smoke",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
-        "@playwright/test": "1.39.0",
-        "@types/node": "^20.16.10",
-        "concurrently": "9.1.2",
-        "cross-env": "7.0.3",
-        "html-webpack-plugin": "^5.5.0",
-        "playwright-watch": "1.3.23",
-        "ts-loader": "^9.5.7",
-        "typescript": "^6.0.0",
-        "webpack": "^5.90.3",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.0.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/15-ts6-webpack-smoke/node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/15-ts6-webpack-smoke/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/__e2e__/16-ts7-webpack-smoke": {
-      "name": "@__e2e__/16-ts7-webpack-smoke",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
-        "@playwright/test": "1.39.0",
-        "@types/node": "^20.16.10",
-        "@typescript/native": "npm:typescript@~7.0.2",
-        "concurrently": "9.1.2",
-        "cross-env": "7.0.3",
-        "html-webpack-plugin": "^5.5.0",
-        "playwright-watch": "1.3.23",
-        "ts-loader": "^9.5.7",
-        "typescript": "npm:@typescript/typescript6@^6.0.2",
-        "webpack": "^5.90.3",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.0.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/16-ts7-webpack-smoke/node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/16-ts7-webpack-smoke/node_modules/typescript": {
-      "name": "@typescript/typescript6",
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
-      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@typescript/old": "npm:typescript@^6"
-      },
-      "bin": {
-        "tsc6": "bin/tsc6"
-      }
-    },
-    "packages/__e2e__/2-hmr-vite": {
-      "name": "@__e2e__/2-hmr-vite",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@aurelia/vite-plugin": "2.0.0-rc.1",
-        "@playwright/test": "1.39.0",
-        "@types/node": "^20.16.10",
-        "html-webpack-plugin": "^5.5.0",
-        "playwright-watch": "1.3.23",
-        "ts-loader": "^9.3.0",
-        "webpack": "^5.90.3",
-        "webpack-cli": "^5.1.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/2-hmr-vite/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/3-hmr-webpack": {
-      "name": "@__e2e__/3-hmr-webpack",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/compat-v1": "2.0.0-rc.1",
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
-        "@playwright/test": "1.39.0",
-        "@types/node": "^20.16.10",
-        "array-flatten": "^3.0.0",
-        "html-webpack-plugin": "^5.5.0",
-        "playwright-watch": "1.3.23",
-        "ts-loader": "^9.3.0",
-        "webpack": "^5.90.3",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.0.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/3-hmr-webpack/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/4-i18n": {
-      "name": "@__e2e__/4-i18n",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/i18n": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/validation": "2.0.0-rc.1",
-        "i18next": ">= 17.3.1",
-        "i18next-fetch-backend": "^2.2.0",
-        "i18next-intervalplural-postprocessor": "^1.0.0"
-      },
-      "devDependencies": {
-        "@aurelia/vite-plugin": "2.0.0-rc.1",
-        "@playwright/test": "1.39.0",
-        "@types/mocha": "10.0.6",
-        "@types/node": "^20.16.10",
-        "playwright": "1.39.0",
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/4-i18n/node_modules/@types/mocha": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
-      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/__e2e__/4-i18n/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/4-i18n/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/__e2e__/5-router-direct": {
-      "name": "@__e2e__/5-router-direct",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/router-direct": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@playwright/test": "1.39.0",
-        "@types/node": "^20.16.10",
-        "playwright-watch": "1.3.23",
-        "webpack": "^5.90.3",
-        "webpack-bundle-analyzer": "^4.10.1",
-        "webpack-cli": "^5.1.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/5-router-direct/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/6-router": {
-      "name": "@__e2e__/6-router",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "animejs": "^4.x",
-        "aurelia": "2.0.0-rc.1",
-        "perf-monitor": "0.6.0"
-      },
-      "devDependencies": {
-        "@playwright/test": "1.39.0",
-        "@types/node": "^20.16.10",
-        "playwright-watch": "1.3.23",
-        "webpack": "^5.90.3",
-        "webpack-bundle-analyzer": "^4.10.1",
-        "webpack-cli": "^5.1.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/6-router/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/7-select-safari16": {
-      "name": "@__e2e__/7-select-safari16",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/router-direct": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@playwright/test": "1.39.0",
-        "@types/node": "^20.16.10",
-        "playwright-watch": "1.3.23",
-        "webpack": "^5.90.3",
-        "webpack-bundle-analyzer": "^4.10.1",
-        "webpack-cli": "^5.1.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/7-select-safari16/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/8-ui-virtualization": {
-      "name": "@__e2e__/8-ui-virtualization",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/router-direct": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/ui-virtualization": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@aurelia/webpack-loader": "2.0.0-rc.1",
-        "@types/node": "^20.16.10",
-        "html-webpack-plugin": "^5.5.0",
-        "ts-loader": "^9.3.0",
-        "typescript": "5.9.2",
-        "webpack": "^5.90.3",
-        "webpack-bundle-analyzer": "^4.10.1",
-        "webpack-cli": "^5.1.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/8-ui-virtualization/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__e2e__/8-ui-virtualization/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/__e2e__/9-vite-wo-convention": {
-      "name": "@__e2e__/9-vite-wo-convention",
-      "version": "2.0.0-beta.25",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "aurelia": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@aurelia/vite-plugin": "2.0.0-rc.1",
-        "@playwright/test": "1.39.0",
-        "@types/node": "^20.16.10",
-        "html-webpack-plugin": "^5.5.0",
-        "playwright-watch": "1.3.23",
-        "ts-loader": "^9.3.0",
-        "webpack": "^5.90.3",
-        "webpack-cli": "^5.1.4"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__e2e__/9-vite-wo-convention/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__tests__": {
-      "name": "@aurelia/__tests__",
-      "version": "2.0.0-rc",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/compat-v1": "2.0.0-rc.1",
-        "@aurelia/dialog": "2.0.0-rc.1",
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/i18n": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/router": "2.0.0-rc.1",
-        "@aurelia/router-direct": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/state": "2.0.0-rc.1",
-        "@aurelia/store-v1": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1",
-        "@aurelia/testing": "2.0.0-rc.1",
-        "@aurelia/ui-virtualization": "2.0.0-rc.1",
-        "@aurelia/validation": "2.0.0-rc.1",
-        "@aurelia/validation-html": "2.0.0-rc.1",
-        "@aurelia/validation-i18n": "2.0.0-rc.1",
-        "@aurelia/web-components": "2.0.0-rc.1",
-        "cssstyle": "4.3.1",
-        "i18next": ">= 17.3.1",
-        "jsdom": "24.1.0",
-        "nwsapi": "2.2.12",
-        "rxjs": "^7.8.1",
-        "typescript": "5.9.2"
-      },
-      "devDependencies": {
-        "@types/jsdom": "^21.1.7",
-        "@types/karma": "^6.3.8",
-        "@types/mocha": "10.0.6",
-        "@types/node": "^20.16.10",
-        "cross-env": "^7.0.2",
-        "full-icu": "^1.4.0",
-        "istanbul": "^0.4.5",
-        "karma": "^6.4.3",
-        "karma-chrome-launcher": "^3.2.0",
-        "karma-coverage": "^2.2.1",
-        "karma-coverage-istanbul-instrumenter": "^1.0.4",
-        "karma-coverage-istanbul-reporter": "^3.0.3",
-        "karma-firefox-launcher": "^2.1.3",
-        "karma-min-reporter": "^0.1.0",
-        "karma-mocha": "^2.0.1",
-        "karma-mocha-reporter": "^2.2.5",
-        "karma-safari-launcher": "1.0.0",
-        "karma-sourcemap-loader": "^0.4.0",
-        "mocha": "10.3.0",
-        "source-map": "^0.7.3",
-        "source-map-support": "^0.5.21",
-        "ts-node": "10.9.1",
-        "xmlbuilder": "15.1.1"
-      },
-      "engines": {
-        "node": ">=14.15.0",
-        "npm": ">=6.14.8"
-      }
-    },
-    "packages/__tests__/node_modules/@types/mocha": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
-      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/__tests__/node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "packages/__tests__/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "packages/__tests__/node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "packages/__tests__/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/addons": {
-      "name": "@aurelia/addons",
-      "version": "2.0.0-rc",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/addons/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/aurelia": {
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/fetch-client": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/aurelia/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/compat-v1": {
-      "name": "@aurelia/compat-v1",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/compat-v1/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/dialog": {
-      "name": "@aurelia/dialog",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/dialog/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/expression-parser": {
-      "name": "@aurelia/expression-parser",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/expression-parser/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/fetch-client": {
-      "name": "@aurelia/fetch-client",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/fetch-client/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/i18n": {
-      "name": "@aurelia/i18n",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1",
-        "i18next": ">= 17.3.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/i18n/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/kernel": {
-      "name": "@aurelia/kernel",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/kernel/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/metadata": {
-      "name": "@aurelia/metadata",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/metadata/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/platform": {
-      "name": "@aurelia/platform",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/platform-browser": {
-      "name": "@aurelia/platform-browser",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/platform": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/platform-browser/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/platform/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/route-recognizer": {
-      "name": "@aurelia/route-recognizer",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/route-recognizer/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/router": {
-      "name": "@aurelia/router",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/router-direct": {
-      "name": "@aurelia/router-direct",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/route-recognizer": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/router-direct/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/router/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/runtime": {
-      "name": "@aurelia/runtime",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/runtime-html": {
-      "name": "@aurelia/runtime-html",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/runtime-html/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/runtime/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/state": {
-      "name": "@aurelia/state",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/state/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/store-v1": {
-      "name": "@aurelia/store-v1",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "rxjs": "^7.8.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/store-v1/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/template-compiler": {
-      "name": "@aurelia/template-compiler",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/template-compiler/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/testing": {
-      "name": "@aurelia/testing",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "@types/mocha": "10.0.6",
-        "jsdom": "24.1.0",
-        "mocha": "10.3.0",
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/testing/node_modules/@types/mocha": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
-      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/testing/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/ui-virtualization": {
-      "name": "@aurelia/ui-virtualization",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/template-compiler": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/ui-virtualization/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/validation": {
-      "name": "@aurelia/validation",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/validation-html": {
-      "name": "@aurelia/validation-html",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/validation": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/validation-html/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/validation-i18n": {
-      "name": "@aurelia/validation-i18n",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/expression-parser": "2.0.0-rc.1",
-        "@aurelia/i18n": "2.0.0-rc.1",
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/platform": "2.0.0-rc.1",
-        "@aurelia/platform-browser": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1",
-        "@aurelia/validation": "2.0.0-rc.1",
-        "@aurelia/validation-html": "2.0.0-rc.1",
-        "i18next": ">= 17.3.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/validation-i18n/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/validation/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "packages/web-components": {
-      "name": "@aurelia/web-components",
-      "version": "2.0.0-rc.1",
-      "license": "MIT",
-      "dependencies": {
-        "@aurelia/kernel": "2.0.0-rc.1",
-        "@aurelia/metadata": "2.0.0-rc.1",
-        "@aurelia/runtime": "2.0.0-rc.1",
-        "@aurelia/runtime-html": "2.0.0-rc.1"
-      },
-      "devDependencies": {
-        "typescript": "5.9.2"
-      },
-      "engines": {
-        "node": ">=20.16.0"
-      }
-    },
-    "packages/web-components/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@__e2e__/14-vite8-decorators": {
-      "resolved": "packages/__e2e__/14-vite8-decorators",
-      "link": true
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
-      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
-      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
-      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
-      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
-      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
-      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
-      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
-      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
-      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
-      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
-      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
-      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
-      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
-      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "2.0.0-alpha.3",
-        "@emnapi/runtime": "2.0.0-alpha.3",
-        "@napi-rs/wasm-runtime": "^1.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "2.0.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
-      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
-      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
-        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
-      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
-      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@swc/wasm": {
-      "version": "1.15.47",
-      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.15.47.tgz",
-      "integrity": "sha512-AdcxrBWz13mPnXxzxr5Lkxkgknwi0fAaArdehpYENB/iIds+WEWVcof3FJKfYAPP7TOeCsaSTKFTSsP3/YX7iw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/lightningcss": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.33.0",
-        "lightningcss-darwin-arm64": "1.33.0",
-        "lightningcss-darwin-x64": "1.33.0",
-        "lightningcss-freebsd-x64": "1.33.0",
-        "lightningcss-linux-arm-gnueabihf": "1.33.0",
-        "lightningcss-linux-arm64-gnu": "1.33.0",
-        "lightningcss-linux-arm64-musl": "1.33.0",
-        "lightningcss-linux-x64-gnu": "1.33.0",
-        "lightningcss-linux-x64-musl": "1.33.0",
-        "lightningcss-win32-arm64-msvc": "1.33.0",
-        "lightningcss-win32-x64-msvc": "1.33.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/rolldown": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
-      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.142.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.1",
-        "@rolldown/binding-darwin-arm64": "1.2.1",
-        "@rolldown/binding-darwin-x64": "1.2.1",
-        "@rolldown/binding-freebsd-x64": "1.2.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
-        "@rolldown/binding-linux-arm64-musl": "1.2.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
-        "@rolldown/binding-linux-x64-gnu": "1.2.1",
-        "@rolldown/binding-linux-x64-musl": "1.2.1",
-        "@rolldown/binding-openharmony-arm64": "1.2.1",
-        "@rolldown/binding-wasm32-wasi": "1.2.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
-        "@rolldown/binding-win32-x64-msvc": "1.2.1"
-      }
-    },
-    "packages-tooling/vite-plugin/node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "packages/__e2e__/14-vite8-decorators": {
       "name": "@__e2e__/14-vite8-decorators",
       "version": "2.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "aurelia": "2.0.0-rc.1"
+        "aurelia": "2.0.0-rc.2"
       },
       "devDependencies": {
-        "@aurelia/vite-plugin": "2.0.0-rc.1",
+        "@aurelia/vite-plugin": "2.0.0-rc.2",
         "@playwright/test": "1.39.0",
         "@types/node": "^20.16.10",
         "vite": "^8.0.0"
@@ -29878,6 +28521,1421 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "packages/__e2e__/15-ts6-webpack-smoke": {
+      "name": "@__e2e__/15-ts6-webpack-smoke",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
+        "@playwright/test": "1.39.0",
+        "@types/node": "^20.16.10",
+        "concurrently": "9.1.2",
+        "cross-env": "7.0.3",
+        "html-webpack-plugin": "^5.5.0",
+        "playwright-watch": "1.3.23",
+        "ts-loader": "^9.5.7",
+        "typescript": "^6.0.0",
+        "webpack": "^5.90.3",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/15-ts6-webpack-smoke/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/15-ts6-webpack-smoke/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/__e2e__/16-ts7-webpack-smoke": {
+      "name": "@__e2e__/16-ts7-webpack-smoke",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
+        "@playwright/test": "1.39.0",
+        "@types/node": "^20.16.10",
+        "@typescript/native": "npm:typescript@~7.0.2",
+        "concurrently": "9.1.2",
+        "cross-env": "7.0.3",
+        "html-webpack-plugin": "^5.5.0",
+        "playwright-watch": "1.3.23",
+        "ts-loader": "^9.5.7",
+        "typescript": "npm:@typescript/typescript6@^6.0.2",
+        "webpack": "^5.90.3",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/16-ts7-webpack-smoke/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/16-ts7-webpack-smoke/node_modules/typescript": {
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
+      },
+      "bin": {
+        "tsc6": "bin/tsc6"
+      }
+    },
+    "packages/__e2e__/2-hmr-vite": {
+      "name": "@__e2e__/2-hmr-vite",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@aurelia/vite-plugin": "2.0.0-rc.2",
+        "@playwright/test": "1.39.0",
+        "@types/node": "^20.16.10",
+        "html-webpack-plugin": "^5.5.0",
+        "playwright-watch": "1.3.23",
+        "ts-loader": "^9.3.0",
+        "webpack": "^5.90.3",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/2-hmr-vite/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/3-hmr-webpack": {
+      "name": "@__e2e__/3-hmr-webpack",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/compat-v1": "2.0.0-rc.2",
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
+        "@playwright/test": "1.39.0",
+        "@types/node": "^20.16.10",
+        "array-flatten": "^3.0.0",
+        "html-webpack-plugin": "^5.5.0",
+        "playwright-watch": "1.3.23",
+        "ts-loader": "^9.3.0",
+        "webpack": "^5.90.3",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/3-hmr-webpack/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/4-i18n": {
+      "name": "@__e2e__/4-i18n",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/i18n": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/validation": "2.0.0-rc.2",
+        "i18next": ">= 17.3.1",
+        "i18next-fetch-backend": "^2.2.0",
+        "i18next-intervalplural-postprocessor": "^1.0.0"
+      },
+      "devDependencies": {
+        "@aurelia/vite-plugin": "2.0.0-rc.2",
+        "@playwright/test": "1.39.0",
+        "@types/mocha": "10.0.6",
+        "@types/node": "^20.16.10",
+        "playwright": "1.39.0",
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/4-i18n/node_modules/@types/mocha": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/__e2e__/4-i18n/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/4-i18n/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/__e2e__/5-router-direct": {
+      "name": "@__e2e__/5-router-direct",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/router-direct": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.39.0",
+        "@types/node": "^20.16.10",
+        "playwright-watch": "1.3.23",
+        "webpack": "^5.90.3",
+        "webpack-bundle-analyzer": "^4.10.1",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/5-router-direct/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/6-router": {
+      "name": "@__e2e__/6-router",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "animejs": "^4.x",
+        "aurelia": "2.0.0-rc.2",
+        "perf-monitor": "0.6.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.39.0",
+        "@types/node": "^20.16.10",
+        "playwright-watch": "1.3.23",
+        "webpack": "^5.90.3",
+        "webpack-bundle-analyzer": "^4.10.1",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/6-router/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/7-select-safari16": {
+      "name": "@__e2e__/7-select-safari16",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/router-direct": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.39.0",
+        "@types/node": "^20.16.10",
+        "playwright-watch": "1.3.23",
+        "webpack": "^5.90.3",
+        "webpack-bundle-analyzer": "^4.10.1",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/7-select-safari16/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/8-ui-virtualization": {
+      "name": "@__e2e__/8-ui-virtualization",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/router-direct": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/ui-virtualization": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@aurelia/webpack-loader": "2.0.0-rc.2",
+        "@types/node": "^20.16.10",
+        "html-webpack-plugin": "^5.5.0",
+        "ts-loader": "^9.3.0",
+        "typescript": "5.9.2",
+        "webpack": "^5.90.3",
+        "webpack-bundle-analyzer": "^4.10.1",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/8-ui-virtualization/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__e2e__/8-ui-virtualization/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/__e2e__/9-vite-wo-convention": {
+      "name": "@__e2e__/9-vite-wo-convention",
+      "version": "2.0.0-beta.25",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "aurelia": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@aurelia/vite-plugin": "2.0.0-rc.2",
+        "@playwright/test": "1.39.0",
+        "@types/node": "^20.16.10",
+        "html-webpack-plugin": "^5.5.0",
+        "playwright-watch": "1.3.23",
+        "ts-loader": "^9.3.0",
+        "webpack": "^5.90.3",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__e2e__/9-vite-wo-convention/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__tests__": {
+      "name": "@aurelia/__tests__",
+      "version": "2.0.0-rc",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/compat-v1": "2.0.0-rc.2",
+        "@aurelia/dialog": "2.0.0-rc.2",
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/i18n": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/router": "2.0.0-rc.2",
+        "@aurelia/router-direct": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/state": "2.0.0-rc.2",
+        "@aurelia/store-v1": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2",
+        "@aurelia/testing": "2.0.0-rc.2",
+        "@aurelia/ui-virtualization": "2.0.0-rc.2",
+        "@aurelia/validation": "2.0.0-rc.2",
+        "@aurelia/validation-html": "2.0.0-rc.2",
+        "@aurelia/validation-i18n": "2.0.0-rc.2",
+        "@aurelia/web-components": "2.0.0-rc.2",
+        "cssstyle": "4.3.1",
+        "i18next": ">= 17.3.1",
+        "jsdom": "24.1.0",
+        "nwsapi": "2.2.12",
+        "rxjs": "^7.8.1",
+        "typescript": "5.9.2"
+      },
+      "devDependencies": {
+        "@types/jsdom": "^21.1.7",
+        "@types/karma": "^6.3.8",
+        "@types/mocha": "10.0.6",
+        "@types/node": "^20.16.10",
+        "cross-env": "^7.0.2",
+        "full-icu": "^1.4.0",
+        "istanbul": "^0.4.5",
+        "karma": "^6.4.3",
+        "karma-chrome-launcher": "^3.2.0",
+        "karma-coverage": "^2.2.1",
+        "karma-coverage-istanbul-instrumenter": "^1.0.4",
+        "karma-coverage-istanbul-reporter": "^3.0.3",
+        "karma-firefox-launcher": "^2.1.3",
+        "karma-min-reporter": "^0.1.0",
+        "karma-mocha": "^2.0.1",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "1.0.0",
+        "karma-sourcemap-loader": "^0.4.0",
+        "mocha": "10.3.0",
+        "source-map": "^0.7.3",
+        "source-map-support": "^0.5.21",
+        "ts-node": "10.9.1",
+        "xmlbuilder": "15.1.1"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=6.14.8"
+      }
+    },
+    "packages/__tests__/node_modules/@types/mocha": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/__tests__/node_modules/@types/node": {
+      "version": "20.19.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
+      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/__tests__/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/__tests__/node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "packages/__tests__/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/addons": {
+      "name": "@aurelia/addons",
+      "version": "2.0.0-rc",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/addons/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/aurelia": {
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/fetch-client": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/aurelia/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/compat-v1": {
+      "name": "@aurelia/compat-v1",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/compat-v1/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/dialog": {
+      "name": "@aurelia/dialog",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/dialog/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/expression-parser": {
+      "name": "@aurelia/expression-parser",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/expression-parser/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/fetch-client": {
+      "name": "@aurelia/fetch-client",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/fetch-client/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/i18n": {
+      "name": "@aurelia/i18n",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2",
+        "i18next": ">= 17.3.1"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/i18n/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/kernel": {
+      "name": "@aurelia/kernel",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/kernel/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/metadata": {
+      "name": "@aurelia/metadata",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/metadata/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/platform": {
+      "name": "@aurelia/platform",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/platform-browser": {
+      "name": "@aurelia/platform-browser",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/platform": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/platform-browser/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/platform/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/route-recognizer": {
+      "name": "@aurelia/route-recognizer",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/route-recognizer/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/router": {
+      "name": "@aurelia/router",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/router-direct": {
+      "name": "@aurelia/router-direct",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/route-recognizer": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/router-direct/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/router/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/runtime": {
+      "name": "@aurelia/runtime",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/runtime-html": {
+      "name": "@aurelia/runtime-html",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/runtime-html/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/runtime/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/state": {
+      "name": "@aurelia/state",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/state/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/store-v1": {
+      "name": "@aurelia/store-v1",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "rxjs": "^7.8.1"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/store-v1/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/template-compiler": {
+      "name": "@aurelia/template-compiler",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/template-compiler/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/testing": {
+      "name": "@aurelia/testing",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@types/mocha": "10.0.6",
+        "jsdom": "24.1.0",
+        "mocha": "10.3.0",
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/testing/node_modules/@types/mocha": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/testing/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/ui-virtualization": {
+      "name": "@aurelia/ui-virtualization",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/template-compiler": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/ui-virtualization/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/validation": {
+      "name": "@aurelia/validation",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/validation-html": {
+      "name": "@aurelia/validation-html",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/validation": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/validation-html/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/validation-i18n": {
+      "name": "@aurelia/validation-i18n",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/expression-parser": "2.0.0-rc.2",
+        "@aurelia/i18n": "2.0.0-rc.2",
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/platform": "2.0.0-rc.2",
+        "@aurelia/platform-browser": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2",
+        "@aurelia/validation": "2.0.0-rc.2",
+        "@aurelia/validation-html": "2.0.0-rc.2",
+        "i18next": ">= 17.3.1"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/validation-i18n/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/validation/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/web-components": {
+      "name": "@aurelia/web-components",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-rc.2",
+        "@aurelia/metadata": "2.0.0-rc.2",
+        "@aurelia/runtime": "2.0.0-rc.2",
+        "@aurelia/runtime-html": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "packages/web-components/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/packages-tooling/__tests__/src/babel-jest/index.spec.ts
+++ b/packages-tooling/__tests__/src/babel-jest/index.spec.ts
@@ -8,7 +8,10 @@ import { makeProjectConfig } from '../jest-test-utils/config';
 
 function makePreprocess(_fileExists: (unit: IFileUnit, p: string) => boolean) {
   return function (unit: IFileUnit, options: IOptionalPreprocessOptions) {
-    return preprocess(unit, options, _fileExists);
+    return preprocess(unit, options, {
+      fileExists: _fileExists,
+      readFile: () => '',
+    });
   };
 }
 

--- a/packages-tooling/__tests__/src/plugin-conventions/options.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/options.spec.ts
@@ -11,6 +11,7 @@ describe('preprocessOptions', function () {
         templateExtensions: ['.haml', '.html', '.jade', '.md', '.pug', '.slim', '.slm'],
         useCSSModule: false,
         hmr: true,
+        isDev: true,
         enableConventions: true,
         experimentalTemplateTypeCheck: false,
         hmrModule: 'module'
@@ -31,6 +32,7 @@ describe('preprocessOptions', function () {
         templateExtensions: ['.haml', '.html', '.jade', '.markdown', '.md', '.pug', '.slim', '.slm'],
         useCSSModule: false,
         hmr: true,
+        isDev: true,
         enableConventions: true,
         experimentalTemplateTypeCheck: false,
         hmrModule: 'module'
@@ -58,6 +60,7 @@ describe('preprocessOptions', function () {
         useProcessedFilePairFilename: true,
         useCSSModule: false,
         hmr: true,
+        isDev: true,
         enableConventions: true,
         experimentalTemplateTypeCheck: false,
         hmrModule: 'module'
@@ -85,6 +88,7 @@ describe('preprocessOptions', function () {
         useCSSModule: true,
         useProcessedFilePairFilename: true,
         hmr: true,
+        isDev: true,
         enableConventions: true,
         experimentalTemplateTypeCheck: false,
         hmrModule: 'module'

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess.spec.ts
@@ -1,8 +1,52 @@
 import * as path from 'path';
-import { preprocess, IFileUnit } from '@aurelia/plugin-conventions';
+import * as fs from 'fs';
+import * as os from 'os';
+import { preprocess, IFileUnit, IFileUnitHost } from '@aurelia/plugin-conventions';
+import { nodeFileUnitHost } from '@aurelia/plugin-conventions/node';
 import { assert } from '@aurelia/testing';
 
+function host(fileExists: IFileUnitHost['fileExists']): IFileUnitHost {
+  return {
+    fileExists,
+    readFile: () => '',
+  };
+}
+
 describe('preprocess', function () {
+  it('produces the same output with in-memory and Node file hosts', function () {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'au-conventions-'));
+    const source = 'export class UserCard {}';
+    const template = '<template class="card">User</template>';
+    const style = '.card { display: block; }';
+    const memoryFiles = new Map([
+      ['/src/user-card.ts', source],
+      ['/src/user-card.html', template],
+      ['/src/user-card.css', style],
+    ]);
+    const memoryHost: IFileUnitHost = {
+      fileExists(unit, filePath) {
+        return memoryFiles.has(resolveMemoryPath(unit, filePath));
+      },
+      readFile(unit, filePath) {
+        return memoryFiles.get(resolveMemoryPath(unit, filePath))!;
+      },
+    };
+
+    try {
+      fs.writeFileSync(path.join(root, 'user-card.ts'), source);
+      fs.writeFileSync(path.join(root, 'user-card.html'), template);
+      fs.writeFileSync(path.join(root, 'user-card.css'), style);
+
+      const options = { hmr: false };
+      const memoryResult = preprocess({ path: '/src/user-card.ts', contents: source }, options, memoryHost)!;
+      const nodeResult = preprocess({ path: path.join(root, 'user-card.ts'), contents: source }, options, nodeFileUnitHost)!;
+
+      assert.equal(memoryResult.code, nodeResult.code);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('transforms html file', function () {
     const html = '<template></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime-html';
@@ -19,7 +63,7 @@ export function register(container) {
   container.register(_e);
 }
 `;
-    const result = preprocess({ path: path.join('src', 'foo-bar.html'), contents: html }, { hmr: false, enableConventions: true }, () => false)!;
+    const result = preprocess({ path: path.join('src', 'foo-bar.html'), contents: html }, { hmr: false, enableConventions: true }, host(() => false))!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
   });
@@ -51,7 +95,7 @@ export function register(container) {
         hmr: false,
         enableConventions: true
       },
-      (unit: IFileUnit, filePath: string) => filePath === './foo-bar.less'
+      host((unit: IFileUnit, filePath: string) => filePath === './foo-bar.less')
     )!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
@@ -85,7 +129,7 @@ export function register(container) {
         hmr: false,
         enableConventions: true
       },
-      (unit: IFileUnit, filePath: string) => filePath === './foo-bar.module.less'
+      host((unit: IFileUnit, filePath: string) => filePath === './foo-bar.module.less')
     )!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
@@ -120,7 +164,7 @@ export function register(container) {
         hmr: false,
         enableConventions: true
       },
-      () => false
+      host(() => false)
     )!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
@@ -155,7 +199,7 @@ export function register(container) {
         hmr: false,
         enableConventions: true
       },
-      (unit: IFileUnit, filePath: string) => filePath === './foo.ts'
+      host((unit: IFileUnit, filePath: string) => filePath === './foo.ts')
     )!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
@@ -166,7 +210,7 @@ export function register(container) {
     const result = preprocess(
       { path: path.join('src', 'foo.js'), contents: js },
       { hmr: false },
-      () => false
+      host(() => false)
     )!;
     assert.equal(result.code, js);
     assert.equal(result.map.version, 3);
@@ -177,7 +221,7 @@ export function register(container) {
     const result = preprocess(
       { path: path.join('src', 'bar.js'), contents: js },
       { hmr: false },
-      (unit: IFileUnit, filePath: string) => filePath === './bar.html'
+      host((unit: IFileUnit, filePath: string) => filePath === './bar.html')
     )!;
     assert.equal(result.code, js);
     assert.equal(result.map.version, 3);
@@ -197,7 +241,7 @@ export class FooBar {}
         base: 'base'
       },
       { hmr: false },
-      (unit: IFileUnit, filePath: string) => filePath === './foo-bar.html'
+      host((unit: IFileUnit, filePath: string) => filePath === './foo-bar.html')
     )!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
@@ -217,7 +261,7 @@ export class FooBar {}
         base: 'base'
       },
       { hmr: false },
-      (unit: IFileUnit, filePath: string) => filePath === './index.html'
+      host((unit: IFileUnit, filePath: string) => filePath === './index.html')
     )!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
@@ -301,7 +345,7 @@ export class FooBar {}`;
         contents: js
       },
       { hmr: false },
-      (unit: IFileUnit, filePath: string) => filePath === './foo-bar.html'
+      host((unit: IFileUnit, filePath: string) => filePath === './foo-bar.html')
     )!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
@@ -385,9 +429,13 @@ export class FooBar {}`;
         contents: js
       },
       { hmr: false },
-      (unit: IFileUnit, filePath: string) => filePath === './foo-bar.haml'
+      host((unit: IFileUnit, filePath: string) => filePath === './foo-bar.haml')
     )!;
     assert.equal(result.code, expected);
     assert.equal(result.map.version, 3);
   });
 });
+
+function resolveMemoryPath(unit: IFileUnit, filePath: string): string {
+  return path.posix.resolve(path.posix.dirname(unit.path), filePath);
+}

--- a/packages-tooling/__tests__/src/ts-jest/index.spec.ts
+++ b/packages-tooling/__tests__/src/ts-jest/index.spec.ts
@@ -8,7 +8,10 @@ import { makeProjectConfig } from '../jest-test-utils/config';
 
 function makePreprocess(_fileExists: (unit: IFileUnit, p: string) => boolean) {
   return function (unit: IFileUnit, options: IOptionalPreprocessOptions) {
-    return preprocess(unit, options, _fileExists);
+    return preprocess(unit, options, {
+      fileExists: _fileExists,
+      readFile: () => '',
+    });
   };
 }
 

--- a/packages-tooling/babel-jest/src/index.ts
+++ b/packages-tooling/babel-jest/src/index.ts
@@ -1,7 +1,9 @@
 import { IOptionalPreprocessOptions, preprocess, preprocessOptions } from '@aurelia/plugin-conventions';
+import { nodeFileUnitHost } from '@aurelia/plugin-conventions/node';
 import * as babelJest from 'babel-jest';
 import { TransformOptions } from '@babel/core';
 import type { TransformOptions as TransformOptionsJest, SyncTransformer, TransformedSource } from '@jest/transform';
+import { env } from 'process';
 
 const babelTransformer = babelJest.createTransformer() as SyncTransformer<TransformOptions>;
 function _createTransformer(
@@ -10,7 +12,10 @@ function _createTransformer(
   _preprocess = preprocess,
   _babelProcess = babelTransformer.process.bind(babelTransformer)
 ) {
-  const au2Options = preprocessOptions(conventionsOptions as IOptionalPreprocessOptions);
+  const au2Options = preprocessOptions({
+    isDev: env.NODE_ENV !== 'production',
+    ...conventionsOptions as IOptionalPreprocessOptions,
+  });
 
   function getCacheKey(
     fileData: string,
@@ -29,7 +34,8 @@ function _createTransformer(
   ): TransformedSource {
     const result = _preprocess(
       { path: sourcePath, contents: sourceText },
-      au2Options
+      au2Options,
+      nodeFileUnitHost
     );
     if (result !== undefined) {
       return _babelProcess(result.code, sourcePath, transformOptions);

--- a/packages-tooling/parcel-transformer/src/index.ts
+++ b/packages-tooling/parcel-transformer/src/index.ts
@@ -2,6 +2,7 @@ import { Transformer } from '@parcel/plugin';
 import $SourceMap from '@parcel/source-map';
 import * as ParcelSourceMap from '@parcel/source-map';
 import { IOptionalPreprocessOptions, preprocess, preprocessOptions } from '@aurelia/plugin-conventions';
+import { nodeFileUnitHost } from '@aurelia/plugin-conventions/node';
 // eslint-disable-next-line import/no-nodejs-modules
 import { relative, extname } from 'path';
 
@@ -33,6 +34,7 @@ export default new Transformer({
 
     const auOptions = preprocessOptions({
       ...config as IOptionalPreprocessOptions,
+      isDev: options.mode !== 'production',
       stringModuleWrap: (id: string) => `bundle-text:${id}`
     });
     // after html template is compiled to js, parcel will apply full js transformers chain,
@@ -46,7 +48,8 @@ export default new Transformer({
         path: relative(options.projectRoot, asset.filePath.slice()),
         contents: source
       },
-      auOptions
+      auOptions,
+      nodeFileUnitHost
     );
 
     if (!result) {

--- a/packages-tooling/plugin-conventions/package.json
+++ b/packages-tooling/plugin-conventions/package.json
@@ -4,11 +4,25 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs"
+    },
+    "./node": {
+      "types": "./dist/types/node.d.ts",
+      "require": "./dist/cjs/node.cjs",
+      "import": "./dist/esm/node.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "node": [
+        "dist/types/node.d.ts"
+      ]
+    }
+  },
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/plugin-conventions/rollup.config.mjs
+++ b/packages-tooling/plugin-conventions/rollup.config.mjs
@@ -3,4 +3,13 @@ import { createRequire } from 'node:module';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 
-export default getRollupConfig(pkg);
+export default getRollupConfig(pkg, config => {
+  config.input = {
+    index: 'src/index.ts',
+    node: 'src/node.ts',
+  };
+  for (const output of config.output) {
+    output.entryFileNames = output.format === 'es' ? 'esm/[name].mjs' : 'cjs/[name].cjs';
+  }
+  return config;
+});

--- a/packages-tooling/plugin-conventions/src/index.ts
+++ b/packages-tooling/plugin-conventions/src/index.ts
@@ -7,6 +7,7 @@ export { preprocess } from './preprocess';
 export {
   type INameConvention,
   type IFileUnit,
+  type IFileUnitHost,
   type IOptionalPreprocessOptions,
   type IPreprocessOptions,
   defaultCssExtensions,

--- a/packages-tooling/plugin-conventions/src/node.ts
+++ b/packages-tooling/plugin-conventions/src/node.ts
@@ -1,0 +1,7 @@
+import { IFileUnitHost } from './options';
+import { fileExists, readFile } from './file-exists';
+
+export const nodeFileUnitHost: IFileUnitHost = {
+  fileExists,
+  readFile,
+};

--- a/packages-tooling/plugin-conventions/src/options.ts
+++ b/packages-tooling/plugin-conventions/src/options.ts
@@ -18,6 +18,11 @@ export interface IFileUnit {
   readFile?(path: string): string;
 }
 
+export interface IFileUnitHost {
+  fileExists(unit: IFileUnit, path: string): boolean;
+  readFile(unit: IFileUnit, path: string): string;
+}
+
 export interface IOptionalPreprocessOptions {
   defaultShadowOptions?: { mode: 'open' | 'closed' };
   // More details in ./preprocess-html-template.ts
@@ -35,6 +40,7 @@ export interface IOptionalPreprocessOptions {
   // Whenn CSSModule is in use, stringModuleWrap is ignored.
   useCSSModule?: boolean;
   hmr?: boolean;
+  isDev?: boolean;
   enableConventions?: boolean;
   hmrModule?: string;
   /**
@@ -76,6 +82,7 @@ export interface IPreprocessOptions {
   useProcessedFilePairFilename?: boolean;
   useCSSModule: boolean;
   hmr?: boolean;
+  isDev: boolean;
   enableConventions?: boolean;
   hmrModule?: string;
   /**
@@ -118,6 +125,7 @@ export function preprocessOptions(options: IOptionalPreprocessOptions = {}): IPr
     templateExtensions = [],
     useCSSModule = false,
     hmr = true,
+    isDev = true,
     enableConventions = true,
     hmrModule = 'module',
     experimentalTemplateTypeCheck = false,
@@ -130,6 +138,7 @@ export function preprocessOptions(options: IOptionalPreprocessOptions = {}): IPr
     templateExtensions: Array.from(new Set([...defaultTemplateExtensions, ...templateExtensions])).sort(),
     useCSSModule,
     hmr,
+    isDev,
     hmrModule,
     enableConventions,
     experimentalTemplateTypeCheck,

--- a/packages-tooling/plugin-conventions/src/path-utils.ts
+++ b/packages-tooling/plugin-conventions/src/path-utils.ts
@@ -1,0 +1,31 @@
+export function basename(filePath: string, suffix: string = ''): string {
+  const normalized = normalize(filePath);
+  const end = normalized.endsWith('/') ? normalized.length - 1 : normalized.length;
+  const start = normalized.lastIndexOf('/', end - 1) + 1;
+  const name = normalized.slice(start, end);
+  return suffix !== '' && name.endsWith(suffix)
+    ? name.slice(0, -suffix.length)
+    : name;
+}
+
+export function dirname(filePath: string): string {
+  const normalized = normalize(filePath).replace(/\/$/, '');
+  const separator = normalized.lastIndexOf('/');
+  if (separator < 0) {
+    return '';
+  }
+  if (separator === 0) {
+    return '/';
+  }
+  return normalized.slice(0, separator);
+}
+
+export function extname(filePath: string): string {
+  const name = basename(filePath);
+  const dot = name.lastIndexOf('.');
+  return dot <= 0 ? '' : name.slice(dot);
+}
+
+function normalize(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}

--- a/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
@@ -1,10 +1,9 @@
-import * as path from 'path';
 import { type ModifyCodeResult } from 'modify-code';
 import { IFileUnit, IPreprocessOptions } from './options';
 import { stripMetaData } from './strip-meta-data';
 import { resourceName } from './resource-name';
-import { fileExists } from './file-exists';
 import { modifyCode } from './modify-code';
+import { basename, extname } from './path-utils';
 
 // stringModuleWrap is to deal with pure css text module import in shadowDOM mode.
 // For webpack:
@@ -18,7 +17,7 @@ export function preprocessHtmlTemplate(
   unit: IFileUnit,
   options: IPreprocessOptions,
   hasViewModel?: boolean,
-  _fileExists = fileExists,
+  fileExists: (unit: IFileUnit, path: string) => boolean = () => false,
 ): ModifyCodeResult {
   const name = resourceName(unit.path);
   const stripped = stripMetaData(unit.contents);
@@ -26,8 +25,8 @@ export function preprocessHtmlTemplate(
   let { shadowMode } = stripped;
 
   if (unit.filePair) {
-    const basename = path.basename(unit.filePair, path.extname(unit.filePair));
-    if (!deps.some(dep => options.cssExtensions.some(e => dep === `./${basename}${e}`))) {
+    const fileName = basename(unit.filePair, extname(unit.filePair));
+    if (!deps.some(dep => options.cssExtensions.some(e => dep === `./${fileName}${e}`))) {
       // implicit dep ./foo.css for foo.html
       deps.unshift(`./${unit.filePair}`);
     }
@@ -52,15 +51,15 @@ export function preprocessHtmlTemplate(
 
   deps.forEach((d, i) => {
     const aliases = depsAliases[d] ?? {};
-    let ext = path.extname(d);
+    let ext = extname(d);
 
     if (!ext) {
       // When possible, fill up explicit file extension.
       // Parcel requires this to work.
       // https://github.com/aurelia/aurelia/issues/1657
-      if (_fileExists(unit, `${d}.ts`)) {
+      if (fileExists(unit, `${d}.ts`)) {
         ext = '.ts';
-      } else if (_fileExists(unit, `${d}.js`)) {
+      } else if (fileExists(unit, `${d}.js`)) {
         ext = '.js';
       }
       d = d + ext;
@@ -106,7 +105,7 @@ export function preprocessHtmlTemplate(
         const stringModuleId = options.stringModuleWrap ? options.stringModuleWrap(d) : d;
         statements.push(`import d${i} from ${s(stringModuleId)};\n`);
         cssDeps.push(`d${i}`);
-      } else if (useCSSModule || path.basename(d, ext).endsWith('.module')) {
+      } else if (useCSSModule || basename(d, ext).endsWith('.module')) {
         statements.push(`import d${i} from ${s(d)};\n`);
         cssModuleDeps.push(`d${i}`);
       } else {
@@ -126,7 +125,7 @@ export function preprocessHtmlTemplate(
   });
 
   const m = modifyCode('', unit.path);
-  const hmrEnabled = !hasViewModel && options.hmr && process.env.NODE_ENV !== 'production';
+  const hmrEnabled = !hasViewModel && options.hmr && options.isDev;
   m.append(`import { CustomElement } from '@aurelia/runtime-html';\n`);
   if (cssDeps.length > 0 && shadowMode !== null) {
     m.append(`import { shadowCSS } from '@aurelia/runtime-html';\n`);
@@ -203,4 +202,3 @@ export function register(container) {
 function s(input: unknown) {
   return JSON.stringify(input);
 }
-

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -219,7 +219,7 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
   });
 
   let m = modifyCode(unit.contents, unit.path);
-  const hmrEnabled = options.hmr && exportedClassMetadata && process.env.NODE_ENV !== 'production';
+  const hmrEnabled = options.hmr && options.isDev && exportedClassMetadata;
 
   if (options.enableConventions || hmrEnabled) {
     if (runtimeImport.names.length) {
@@ -242,7 +242,7 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
     templateMetadata: templateMetadata
   });
 
-  if (options.hmr && exportedClassMetadata && process.env.NODE_ENV !== 'production') {
+  if (options.hmr && options.isDev && exportedClassMetadata) {
     if (options.getHmrCode) {
       m.append(options.getHmrCode(exportedClassMetadata.name, unit.path));
     }

--- a/packages-tooling/plugin-conventions/src/preprocess.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess.ts
@@ -1,57 +1,54 @@
-import * as path from 'path';
 import { ModifyCodeResult } from 'modify-code';
-import { IFileUnit, IOptionalPreprocessOptions, preprocessOptions } from './options';
+import { IFileUnit, IFileUnitHost, IOptionalPreprocessOptions, preprocessOptions } from './options';
 import { preprocessHtmlTemplate } from './preprocess-html-template';
 import { preprocessResource } from './preprocess-resource';
-import { fileExists, readFile } from './file-exists';
+import { basename, extname } from './path-utils';
 
 export function preprocess(
   unit: IFileUnit,
   options: IOptionalPreprocessOptions,
-  // for testing
-  _fileExists = fileExists,
-  _readFile = readFile,
+  host: IFileUnitHost,
 ): ModifyCodeResult | undefined {
-  const ext = path.extname(unit.path);
-  const basename = path.basename(unit.path, ext);
+  const ext = extname(unit.path);
+  const fileName = basename(unit.path, ext);
   const allOptions = preprocessOptions(options);
   const templateExtensions = allOptions.templateExtensions;
   const useProcessedFilePairFilename = allOptions.useProcessedFilePairFilename;
-  unit.readFile = (path) => _readFile(unit, path);
+  unit.readFile = path => host.readFile(unit, path);
 
   if (allOptions.enableConventions && templateExtensions.includes(ext)) {
     for (const ce of allOptions.cssExtensions) {
-      let filePair: string | null = `${basename}.module${ce}`;
-      if (!_fileExists(unit, `./${filePair}`)) {
-        filePair = `${basename}${ce}`;
-        if (!_fileExists(unit, `./${filePair}`)) continue;
+      let filePair: string | null = `${fileName}.module${ce}`;
+      if (!host.fileExists(unit, `./${filePair}`)) {
+        filePair = `${fileName}${ce}`;
+        if (!host.fileExists(unit, `./${filePair}`)) continue;
       }
 
       // Replace foo.scss with transpiled file name foo.css
-      unit.filePair = useProcessedFilePairFilename ? `${path.basename(filePair, path.extname(filePair))}.css` : filePair;
+      unit.filePair = useProcessedFilePairFilename ? `${basename(filePair, extname(filePair))}.css` : filePair;
       break;
     }
 
     return preprocessHtmlTemplate(
       unit,
       allOptions,
-      allOptions.jsExtensions.some(e => _fileExists(unit, `./${basename}${e}`)),
-      _fileExists
+      allOptions.jsExtensions.some(e => host.fileExists(unit, `./${fileName}${e}`)),
+      host.fileExists.bind(host)
     );
   }
   if (allOptions.jsExtensions.includes(ext)) {
     for (const te of templateExtensions) {
-      const filePair = `${basename}${te}`;
-      if (!_fileExists(unit, `./${filePair}`)) continue;
-      unit.filePair = useProcessedFilePairFilename ? `${basename}.html` : filePair;
+      const filePair = `${fileName}${te}`;
+      if (!host.fileExists(unit, `./${filePair}`)) continue;
+      unit.filePair = useProcessedFilePairFilename ? `${fileName}.html` : filePair;
 
       // Try foo.js and foo-view.html convention.
       // This convention is handled by @view(), not @customElement().
       for (const te of templateExtensions) {
         // Note that this is technically not a nested for-loop, as it is bound to run only once when the file pair is found. Complexity: m+n instead of m*n.
-        const viewPair = `${basename}-view${te}`;
-        if (!_fileExists(unit, `./${viewPair}`)) continue;
-        unit.filePair = useProcessedFilePairFilename ? `${basename}-view.html` : viewPair;
+        const viewPair = `${fileName}-view${te}`;
+        if (!host.fileExists(unit, `./${viewPair}`)) continue;
+        unit.filePair = useProcessedFilePairFilename ? `${fileName}-view.html` : viewPair;
         break;
       }
       break;

--- a/packages-tooling/plugin-conventions/src/resource-name.ts
+++ b/packages-tooling/plugin-conventions/src/resource-name.ts
@@ -1,12 +1,13 @@
-import * as path from 'path';
 import { kebabCase } from '@aurelia/kernel';
+import { basename, dirname, extname } from './path-utils';
 
 // a/foo-bar.xxx -> "foo-bar"
 // a/fooBar.xxx -> "foo-bar"
 // a/foo-bar/index.xxx -> "foo-bar"
 // a/fooBar/index.xxx -> "foo-bar"
 export function resourceName(filePath: string): string {
-  const parsed = path.parse(filePath);
-  const name = parsed.name === 'index' ? path.basename(parsed.dir) : parsed.name;
+  const fileName = basename(filePath);
+  const nameWithoutExtension = basename(fileName, extname(fileName));
+  const name = nameWithoutExtension === 'index' ? basename(dirname(filePath)) : nameWithoutExtension;
   return kebabCase(name);
 }

--- a/packages-tooling/plugin-gulp/src/index.ts
+++ b/packages-tooling/plugin-gulp/src/index.ts
@@ -1,10 +1,12 @@
 import { Transform } from 'stream';
 import { IOptionalPreprocessOptions, preprocess, preprocessOptions } from '@aurelia/plugin-conventions';
+import { nodeFileUnitHost } from '@aurelia/plugin-conventions/node';
 import * as Vinyl from 'vinyl';
 
 export default function (options: IOptionalPreprocessOptions = {}) {
   return plugin({
     ...options,
+    isDev: process.env.NODE_ENV !== 'production',
     useProcessedFilePairFilename: true,
     stringModuleWrap
   });
@@ -28,7 +30,8 @@ export function plugin(
             contents: file.contents.toString(),
             base: file.base
           },
-          allOptions
+          allOptions,
+          nodeFileUnitHost
         );
 
         if (result) {

--- a/packages-tooling/ts-jest/src/index.ts
+++ b/packages-tooling/ts-jest/src/index.ts
@@ -1,8 +1,10 @@
 import { IOptionalPreprocessOptions, preprocess, preprocessOptions } from '@aurelia/plugin-conventions';
+import { nodeFileUnitHost } from '@aurelia/plugin-conventions/node';
 import tsJest, { TsJestTransformerOptions } from 'ts-jest';
 import * as TsJest from 'ts-jest';
 import type { TransformOptions, TransformedSource } from '@jest/transform';
 import * as path from 'path';
+import { env } from 'process';
 
 // eslint-disable-next-line
 const tsJestCreateTransformer = (TsJest as any).createTransformer;
@@ -24,7 +26,10 @@ function _createTransformer(
   _preprocess = preprocess,
   _tsProcess = tsTransformer.process.bind(tsTransformer)
 ) {
-  const au2Options = preprocessOptions(conventionsOptions as IOptionalPreprocessOptions);
+  const au2Options = preprocessOptions({
+    isDev: env.NODE_ENV !== 'production',
+    ...conventionsOptions as IOptionalPreprocessOptions,
+  });
 
   function getCacheKey(
     fileData: string,
@@ -43,7 +48,8 @@ function _createTransformer(
   ): TransformedSource {
     const result = _preprocess(
       { path: sourcePath, contents: sourceText },
-      au2Options
+      au2Options,
+      nodeFileUnitHost
     );
     let newSourcePath = sourcePath;
     if (result !== undefined) {

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -1,4 +1,5 @@
 import { IOptionalPreprocessOptions, preprocess } from '@aurelia/plugin-conventions';
+import { nodeFileUnitHost } from '@aurelia/plugin-conventions/node';
 import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import { resolve, dirname } from 'path';
 import { promises } from 'fs';
@@ -85,8 +86,9 @@ export default function au(options: AureliaPluginOptions = {}) {
             : s;
         },
         stringModuleWrap: (id) => `${id}?inline`,
-        ...additionalOptions
-      });
+        ...additionalOptions,
+        isDev: $config.command !== 'build',
+      }, nodeFileUnitHost);
       return result;
     },
 
@@ -126,8 +128,9 @@ export default function au(options: AureliaPluginOptions = {}) {
         hmrModule: 'import.meta',
         transformHtmlImportSpecifier: s => s.replace(/\.html$/, '.$au.ts'),
         stringModuleWrap: (id) => `${id}?inline`,
-        ...additionalOptions
-      });
+        ...additionalOptions,
+        isDev: $config.command !== 'build',
+      }, nodeFileUnitHost);
       return result!.code;
     }
   };

--- a/packages-tooling/webpack-loader/src/index.ts
+++ b/packages-tooling/webpack-loader/src/index.ts
@@ -1,4 +1,5 @@
 import { IOptionalPreprocessOptions, preprocess, preprocessOptions } from '@aurelia/plugin-conventions';
+import { nodeFileUnitHost } from '@aurelia/plugin-conventions/node';
 import { getOptions } from 'loader-utils';
 import type webpack from 'webpack';
 
@@ -27,8 +28,10 @@ export function loader(
       { path: filePath, contents },
       preprocessOptions({
         ...options,
+        isDev: this.mode !== 'production',
         getHmrCode
-      })
+      }),
+      nodeFileUnitHost
     );
     // webpack uses source-map 0.6.1 typings for RawSourceMap which
     // contains typing error version: string (should be number).


### PR DESCRIPTION
## 📖 Description

Even though we plan to let the language server take over all the convention work, it's still better to have the core utility of plugin convention to be flexible. This PR separates the plugin convention into 2 parts:

- core convention work which is filesystem host agnostic
- platform/host related export for as host providers implementation

So vite/parcel/webpack can plug in the core convention easier, also for usage in the browser.

cc @3cp @fkleuver 