### PR TITLE
fix(preprocess): add validation for missing direct export in convention

### DIFF
--- a/.changeset/gentle-rockets-like.md
+++ b/.changeset/gentle-rockets-like.md
@@ -1,0 +1,6 @@
+---
+"@aurelia/plugin-conventions": minor
+---
+
+Throws on missing export for resource class declaration
+Supports separate export declaration for resource classes

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -28,6 +28,60 @@ describe('preprocessResource', function () {
     assert.equal(result.code, code);
   });
 
+  it('throws when a conventional custom element class is not directly exported', function () {
+    const code = `class Foo {}\n`;
+    assert.throws(() => preprocessResource(
+      {
+        path: path.join('bar', 'foo.js'),
+        contents: code,
+        filePair: 'foo.html'
+      },
+      preprocessOptions({ hmr: false })
+    ), /must be directly exported/);
+  });
+
+  it('injects custom element definition for a class exported via export list', function () {
+    const code = `class LoginPage {\n  message = 'Login';\n}\nexport { LoginPage };\n`;
+    const expected = `import { customElement } from '@aurelia/runtime-html';
+import * as __au2ViewDef from './login-page.html';
+@customElement(__au2ViewDef)
+class LoginPage {
+  message = 'Login';
+}
+export { LoginPage };
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'login-page.js'),
+        contents: code,
+        filePair: 'login-page.html'
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('injects custom element definition for a class exported via default export assignment', function () {
+    const code = `class LoginPage {\n  message = 'Login';\n}\nexport default LoginPage;\n`;
+    const expected = `import { customElement } from '@aurelia/runtime-html';
+import * as __au2ViewDef from './login-page.html';
+@customElement(__au2ViewDef)
+class LoginPage {
+  message = 'Login';
+}
+export default LoginPage;
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'login-page.js'),
+        contents: code,
+        filePair: 'login-page.html'
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects custom element definition', function () {
     const code = `\nexport class FooBar {}\n`;
     const expected = `import { customElement } from '@aurelia/runtime-html';
@@ -197,6 +251,23 @@ export class FooBarCustomAttribute {}
     assert.equal(result.code, expected);
   });
 
+  it('injects custom attribute definition for a class exported via export list', function () {
+    const code = `class FooBarCustomAttribute {}\nexport { FooBarCustomAttribute };\n`;
+    const expected = `import { customAttribute } from '@aurelia/runtime-html';
+@customAttribute('foo-bar')
+class FooBarCustomAttribute {}
+export { FooBarCustomAttribute };
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects custom attribute definition for non-kebab case file name', function () {
     const code = `export class FooBarCustomAttribute {}\n`;
     const expected = `import { customAttribute } from '@aurelia/runtime-html';
@@ -239,6 +310,23 @@ export class FooBar {}
     const expected = `import { templateController } from '@aurelia/runtime-html';
 @templateController('foo-bar')
 export class FooBarTemplateController {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('injects template controller definition for a class exported via export list', function () {
+    const code = `class FooBarTemplateController {}\nexport { FooBarTemplateController };\n`;
+    const expected = `import { templateController } from '@aurelia/runtime-html';
+@templateController('foo-bar')
+class FooBarTemplateController {}
+export { FooBarTemplateController };
 `;
     const result = preprocessResource(
       {
@@ -303,6 +391,23 @@ export class FooBarValueConverter {}
     assert.equal(result.code, expected);
   });
 
+  it('injects value converter definition for a class exported via export list', function () {
+    const code = `class FooBarValueConverter {}\nexport { FooBarValueConverter };\n`;
+    const expected = `import { valueConverter } from '@aurelia/runtime-html';
+@valueConverter('fooBar')
+class FooBarValueConverter {}
+export { FooBarValueConverter };
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects value converter definition for non-kebab case file name', function () {
     const code = `export class FooBarValueConverter {}\n`;
     const expected = `import { valueConverter } from '@aurelia/runtime-html';
@@ -356,6 +461,23 @@ export class FooBarBindingBehavior {}
     assert.equal(result.code, expected);
   });
 
+  it('injects binding behavior definition for a class exported via export list', function () {
+    const code = `class FooBarBindingBehavior {}\nexport { FooBarBindingBehavior };\n`;
+    const expected = `import { bindingBehavior } from '@aurelia/runtime-html';
+@bindingBehavior('fooBar')
+class FooBarBindingBehavior {}
+export { FooBarBindingBehavior };
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects binding behavior definition for non-kebab case file name', function () {
     const code = `export class FooBarBindingBehavior {}\n`;
     const expected = `import { bindingBehavior } from '@aurelia/runtime-html';
@@ -398,6 +520,23 @@ export class FooBar {}
     const expected = `import { bindingCommand } from '@aurelia/runtime-html';
 @bindingCommand('foo-bar')
 export class FooBarBindingCommand {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('injects binding command definition for a class exported via export list', function () {
+    const code = `class FooBarBindingCommand {}\nexport { FooBarBindingCommand };\n`;
+    const expected = `import { bindingCommand } from '@aurelia/runtime-html';
+@bindingCommand('foo-bar')
+class FooBarBindingCommand {}
+export { FooBarBindingCommand };
 `;
     const result = preprocessResource(
       {

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -33,8 +33,11 @@ const {
   isCallExpression,
   isClassDeclaration,
   isExpressionStatement,
+  isExportAssignment,
+  isExportDeclaration,
   isIdentifier,
   isImportDeclaration,
+  isNamedExports,
   isObjectLiteralExpression,
   isPropertyDeclaration,
   isPropertyAccessExpression,
@@ -151,6 +154,10 @@ interface IModifyResourceOptions {
 export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions): ModifyCodeResult {
   const expectedResourceName = resourceName(unit.path);
   const sf = createSourceFile(unit.path, unit.contents, ScriptTarget.Latest, true);
+  const localExports = collectLocalExports(sf);
+  const missingConventionalExport = options.enableConventions && unit.filePair
+    ? findMissingConventionalExport(sf, expectedResourceName, localExports)
+    : void 0;
   let exportedClassMetadata: ClassMetadata | undefined;
   let auImport: ICapturedImport = { names: [], start: 0, end: 0 };
   let runtimeImport: ICapturedImport = { names: [], start: 0, end: 0 };
@@ -189,11 +196,7 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
     }
     if (tryCaptureCustomElementDefine(s, sf, templateMetadata)) return;
 
-    // Only care about export class Foo {...}.
-    // Note this convention simply doesn't work for
-    //   class Foo {}
-    //   export {Foo};
-    const resource = findResource(s, expectedResourceName, unit.filePair, unit.contents, options.enableConventions, templateMetadata, sf);
+    const resource = findResource(s, expectedResourceName, unit.filePair, unit.contents, options.enableConventions, templateMetadata, sf, localExports);
     if (!resource) return;
     const {
       classMetadata,
@@ -217,6 +220,10 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
     if (customName) customElementDecorator = customName;
     if ($defineElementInformation) defineElementInformation = $defineElementInformation;
   });
+
+  if (missingConventionalExport && implicitElement == null && defineElementInformation == null) {
+    throw new Error(`Conventional component '${expectedResourceName}' in '${unit.path}' must be directly exported. Change 'class ${missingConventionalExport} {}' to 'export class ${missingConventionalExport} {}' or add an explicit @customElement export.`);
+  }
 
   let m = modifyCode(unit.contents, unit.path);
   const hmrEnabled = options.hmr && options.isDev && exportedClassMetadata;
@@ -430,7 +437,7 @@ function getClassMembers(node: ClassDeclaration, sf: SourceFile): ClassMember[] 
         ;
       acc.push({
         name: name.escapedText.toString(),
-        accessModifier: accessModifier!,
+        accessModifier,
         memberType,
         dataType: ((m as PropertyDeclaration | MethodDeclaration | GetAccessorDeclaration).type ?? getJSDocType(m))?.getText(sf) ?? 'any',
         methodArguments: memberType === 'method'
@@ -484,7 +491,10 @@ function ensureTokenStart(start: number, code: string) {
   return start;
 }
 
-function isExported(node: Node): boolean {
+function isExported(node: Node, localExports?: ReadonlySet<string>): boolean {
+  if (isClassDeclaration(node) && node.name != null && localExports?.has(node.name.text)) {
+    return true;
+  }
   if (!canHaveModifiers(node)) return false;
   const modifiers = getModifiers(node);
   if (modifiers === void 0) return false;
@@ -495,6 +505,42 @@ function isExported(node: Node): boolean {
 }
 
 const KNOWN_RESOURCE_DECORATORS = ['customElement', 'customAttribute', 'valueConverter', 'bindingBehavior', 'bindingCommand', 'templateController', 'noView', 'inlineView'];
+
+function collectLocalExports(sf: SourceFile): ReadonlySet<string> {
+  const localExports = new Set<string>();
+
+  for (const statement of sf.statements) {
+    if (isExportDeclaration(statement)) {
+      if (statement.moduleSpecifier != null || statement.exportClause == null || !isNamedExports(statement.exportClause)) continue;
+      for (const element of statement.exportClause.elements) {
+        localExports.add(element.propertyName?.text ?? element.name.text);
+      }
+      continue;
+    }
+
+    if (!isExportAssignment(statement) || statement.isExportEquals || !isIdentifier(statement.expression)) continue;
+    localExports.add(statement.expression.text);
+  }
+
+  return localExports;
+}
+
+function findMissingConventionalExport(sf: SourceFile, expectedResourceName: string, localExports: ReadonlySet<string>): string | undefined {
+  let missingClassName: string | undefined;
+
+  for (const statement of sf.statements) {
+    if (!isClassDeclaration(statement) || statement.name == null) continue;
+
+    const className = statement.name.text;
+    const { name, type } = nameConvention(className);
+    if (type !== 'customElement' || !isKindOfSame(name, expectedResourceName)) continue;
+
+    if (isExported(statement, localExports)) return;
+    missingClassName ??= className;
+  }
+
+  return missingClassName;
+}
 
 function isKindOfSame(name1: string, name2: string): boolean {
   return name1.replace(/-/g, '') === name2.replace(/-/g, '');
@@ -610,10 +656,11 @@ function findResource(
   useConvention: boolean | undefined,
   templateMetadata: ITemplateMetadata[],
   sf: SourceFile,
+  localExports: ReadonlySet<string>,
 ): IFoundResource | void {
 
-  // Ignore non-class declarations, anonymous classes, and non-exported classes (in case convention is used).
-  if (!isClassDeclaration(node) || !node.name || !isExported(node) && !useConvention) return;
+  // Ignore non-class declarations, anonymous classes, and non-exported classes.
+  if (!isClassDeclaration(node) || !node.name || !isExported(node, localExports)) return;
   const pos = ensureTokenStart(node.pos, code);
 
   const className = node.name.text;

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -653,7 +653,7 @@ function findResource(
   expectedResourceName: string,
   filePair: string | undefined,
   code: string,
-  useConvention: boolean | undefined,
+  _useConvention: boolean | undefined,
   templateMetadata: ITemplateMetadata[],
   sf: SourceFile,
   localExports: ReadonlySet<string>,


### PR DESCRIPTION
feat(preprocess): allow declare class and export statement separately

## 📖 Description

Add a bit more check/handling in plugin convention so it throws on this
```ts
class MyEl {} // missing export entirely
```
and allows this
```ts
class MyEl {}

export { MyEl }

// or

export default MyEl
```

### 🎫 Issues

Closes #1278 
Closes #846 

cc @3cp 
cc @fkleuver does allowing default export affect LS in any way?