### PR TITLE
fix(runtime): correct observable class decorator typing

### DIFF
--- a/.changeset/fix-observable-class-config-types.md
+++ b/.changeset/fix-observable-class-config-types.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/runtime": patch
+---
+
+Object-form `@observable({ name, callback, set })` declarations now type-check on classes as well as fields, matching the existing runtime behavior.

--- a/packages/__tests__/src/3-runtime-html/decorator-observable.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/decorator-observable.spec.ts
@@ -132,6 +132,50 @@ describe('3-runtime-html/decorator-observable.spec.ts', function () {
     assert.strictEqual(callCount, 2);
   });
 
+  it('supports object configuration as class and field decorators', function () {
+    const changes: [string, number, unknown][] = [];
+
+    @observable({
+      name: 'classValue',
+      callback: 'classValueChanged',
+      set: value => Number(value),
+    })
+    class Test {
+      public declare classValue: number;
+
+      @observable({
+        callback: 'fieldValueChanged',
+        set: value => Number(value),
+      })
+      public fieldValue = 0;
+
+      public classValueChanged(value: number, oldValue: unknown) {
+        changes.push(['class', value, oldValue]);
+      }
+
+      public fieldValueChanged(value: number, oldValue: unknown) {
+        changes.push(['field', value, oldValue]);
+      }
+    }
+
+    const instance = new Test();
+    assert.strictEqual(instance.classValue, void 0);
+    assert.strictEqual(instance.fieldValue, 0);
+
+    instance.classValue = '1' as unknown as number;
+    instance.fieldValue = '2' as unknown as number;
+    assert.strictEqual(instance.classValue, 1);
+    assert.strictEqual(instance.fieldValue, 2);
+    assert.deepStrictEqual(changes, [
+      ['class', 1, void 0],
+      ['field', 2, 0],
+    ]);
+
+    instance.classValue = 1;
+    instance.fieldValue = 2;
+    assert.strictEqual(changes.length, 2, 'coerced duplicates should not invoke the callbacks');
+  });
+
   describe('with normal app', function () {
     it('works in basic scenario', async function () {
       const noValue = {};

--- a/packages/runtime/src/observable.ts
+++ b/packages/runtime/src/observable.ts
@@ -218,3 +218,29 @@ export const observable = /*@__PURE__*/(() => {
 
   return observable;
 })();
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/**
+ * Compile-time coverage for the public decorator overloads. This function is
+ * removed by dead code elimination.
+ */
+function apiTypeCheck() {
+  @observable({
+    name: 'classValue',
+    callback: 'classValueChanged',
+    set: value => Number(value),
+  })
+  class ClassConfiguredObservable {
+    public declare classValue: number;
+
+    public classValueChanged(value: number, oldValue: unknown): void { /*  */ }
+
+    @observable({
+      callback: 'fieldValueChanged',
+      set: value => Number(value),
+    })
+    public fieldValue = 0;
+
+    public fieldValueChanged(value: number, oldValue: unknown): void { /*  */ }
+  }
+}

--- a/packages/runtime/src/observable.ts
+++ b/packages/runtime/src/observable.ts
@@ -18,6 +18,10 @@ export interface IObservableDefinition {
 type FieldInitializer<TFThis, TValue> = (this: TFThis, initialValue: TValue) => TValue;
 type ObservableFieldDecorator<TFThis, TValue> = (target: undefined, context: ClassFieldDecoratorContext<TFThis, TValue>) => FieldInitializer<TFThis, TValue>;
 type ObservableClassDecorator<TCThis extends Constructable> = (target: TCThis, context: ClassDecoratorContext<TCThis>) => void;
+interface ObservableDecorator {
+  <TCThis extends Constructable>(target: TCThis, context: ClassDecoratorContext<TCThis>): void;
+  <TFThis, TValue>(target: undefined, context: ClassFieldDecoratorContext<TFThis, TValue>): FieldInitializer<TFThis, TValue>;
+}
 
 export const observable = /*@__PURE__*/(() => {
 
@@ -34,7 +38,7 @@ export const observable = /*@__PURE__*/(() => {
   //    class {
   //      @observable({...}) prop
   //    }
-  function observable<TCThis extends Constructable, TFThis, TValue>(config: IObservableDefinition): (target: TCThis | undefined, context: ClassDecoratorContext<TCThis> | ClassFieldDecoratorContext<TFThis, TValue>) => FieldInitializer<TFThis, TValue> | void;
+  function observable(config: IObservableDefinition): ObservableDecorator;
   // for
   //    @observable('') class {}
   //    @observable(5) class {}


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

Object-form `@observable` configuration works as a class decorator at runtime, but its typing caused TypeScript to reject valid class usage with TS1270.

## 💁 Your Solution

Give object-form configuration distinct class and field decorator signatures. Runtime behavior remains unchanged.

## 📑 Test Plan

Added regression coverage for object-configured class and field decorators, including `name`, `callback`, and `set`.

## 📦 Changeset

- [x] Added a changeset