### PR TITLE
fix(runtime-html): enforce structural if/else adjacency

### DIFF
--- a/.changeset/tidy-branches-link.md
+++ b/.changeset/tidy-branches-link.md
@@ -1,0 +1,8 @@
+---
+"@aurelia/runtime-html": patch
+"@aurelia/template-compiler": patch
+---
+
+`else` now enforces its documented relationship with an `if` on the immediately preceding sibling element. Formatting whitespace and HTML comments may remain between them. Text, interpolations, `<let>` bindings, local-template declarations, or elements now end the pair, preventing an unrelated or nested `if` from capturing the branch.
+
+Templates that previously relied on an intervening plain element should move it outside the pair or use an explicit `if.bind` condition.

--- a/docs/user-docs/developer-guides/error-messages/runtime-html/aur0810.md
+++ b/docs/user-docs/developer-guides/error-messages/runtime-html/aur0810.md
@@ -6,18 +6,18 @@
 
 ## Description
 
-This error occurs during template linking when Aurelia encounters an element with an `else` custom attribute, but the immediately preceding element sibling in the DOM (after template compilation) does not have an `if.bind` attribute or another `else` attribute. The `else` attribute must directly follow an `if` or another `else` to form a conditional chain.
+This error occurs during template linking when Aurelia encounters an element with an `else` custom attribute that does not immediately follow an element with `if.bind`. Formatting whitespace and ordinary HTML comments are ignored, but non-whitespace text, interpolations, and intervening elements—including `<let>` or `<template>`—end the conditional pair.
 
 ## Cause
 
-1.  **Incorrect Placement:** The element with the `else` attribute is not placed immediately after the element with the corresponding `if.bind` or `else` attribute in the HTML template. There might be other elements, comments (that aren't removed during compilation), or significant whitespace between them.
+1.  **Incorrect Placement:** Non-whitespace text, an interpolation, or another element—including `<let>` or `<template>`—appears between the `if.bind` and `else` elements.
 2.  **Missing `if.bind`:** The preceding element, which was intended to be the start of the conditional block, is missing the `if.bind` attribute.
 3.  **Template Manipulation:** Manual manipulation of the DOM or compiled template structure before or during linking might disrupt the expected `if`/`else` sequence.
 4.  **Syntax Error:** A simple typo or syntax error in the template might lead to the `else` being misinterpreted or misplaced relative to the `if`.
 
 ## Solution
 
-1.  **Verify Placement:** Ensure the element with the `else` attribute is the immediate sibling following the element with `if.bind` or a preceding `else`. Remove any intervening elements, comments, or excessive whitespace that might interfere. Remember that Aurelia operates on the structure *after* template compilation, so whitespace handling by the browser or compiler can sometimes play a role, though typically direct element adjacency is required.
+1.  **Verify Placement:** Ensure the element with the `else` attribute immediately follows the element with `if.bind`. You may keep indentation, line breaks, and HTML comments between the two branches, but remove or relocate any other content.
 2.  **Add `if.bind`:** If the preceding element is missing `if.bind`, add it with the appropriate condition.
 3.  **Check Template Structure:** Review the HTML template carefully around the `if`/`else` block for any structural issues or typos.
 
@@ -48,7 +48,7 @@ This error occurs during template linking when Aurelia encounters an element wit
 ## Debugging Tips
 
 *   Carefully inspect the HTML source template around the `if` and `else` elements. Pay close attention to the direct sibling relationship.
-*   Use the browser's developer tools ("Inspect Element") to look at the DOM structure *after* Aurelia has processed the template. Verify that the element with `else` directly follows the element with `if` (or a previous `else`) in the rendered DOM structure just before the error occurs (this might require stepping through the linking process or examining the structure just before the error is thrown).
+*   Check the authored template rather than the rendered DOM. Template controllers replace their host elements with render markers and move the active branch, so the post-render DOM no longer shows the original sibling relationship directly.
 *   Temporarily remove the `else` block and ensure the `if` block works correctly on its own.
 *   Simplify the content within the `if` and `else` blocks to basic text to rule out complex content interfering with the structure detection.
 ```

--- a/docs/user-docs/getting-to-know-aurelia/template-controllers.md
+++ b/docs/user-docs/getting-to-know-aurelia/template-controllers.md
@@ -137,24 +137,9 @@ Because the same view gets reused, you can cache work (see `If.cache` and `Promi
 
 When several template controllers decorate the same element, Aurelia walks the instruction list from **right to left** (`packages/template-compiler/src/template-compiler.ts`, section 4.1). Only the right-most controller receives the original compiled template. The controllers to its left only see the marker emitted by the inner controller. This is why sequences like `repeat.for="item of items" if.bind="item.visible"` behave predictably—the `if` sees the repeated view because it is to the right of `repeat`.
 
-Template controllers can also cooperate via the optional `link()` hook. The built-in `else` controller uses it to register its `IViewFactory` with the nearest preceding `if`:
+Template controllers can also cooperate via the optional `link()` hook. The built-in `else` controller uses internal compiler source metadata together with render locations to find the immediately preceding sibling `if` and register its `IViewFactory` with that controller.
 
-```typescript
-import { ICustomAttributeController, IHydratableController } from '@aurelia/runtime-html';
-import { IInstruction } from '@aurelia/template-compiler';
-
-export class ElseTemplateController {
-  public link(
-    parent: IHydratableController,
-    _ownController: ICustomAttributeController,
-    _target: Node,
-    _instruction: IInstruction,
-  ) {
-    const lastChild = parent.children?.at(-1);
-    // lastChild.viewModel will be the matching If instance; hand it our factory
-  }
-}
-```
+Do not infer structural adjacency from `parent.children`: that list contains controllers, but deliberately omits ordinary DOM nodes between them. Custom controllers that need structural linking should establish an explicit compiler/runtime contract or coordinate through a supported parent or DI relationship.
 
 Use this hook whenever two controllers must share state (think `switch` / `case` / `default-case`).
 

--- a/docs/user-docs/templates/conditional-rendering.md
+++ b/docs/user-docs/templates/conditional-rendering.md
@@ -39,6 +39,8 @@ Use `else` immediately after an `if.bind` element to create branching logic:
 </div>
 ```
 
+Formatting whitespace and ordinary HTML comments may appear between the branches. Any other authored content—including non-whitespace text, interpolations, `<let>`, local-template declarations, or elements—ends the pair.
+
 ### Caching Behavior
 
 By default, `if.bind` caches views and view models for performance. Disable caching when you need fresh instances:

--- a/packages/__tests__/src/3-runtime-html/if.integration.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/if.integration.spec.ts
@@ -1,13 +1,16 @@
+import { Registration } from '@aurelia/kernel';
 import {
+  Aurelia,
   CustomAttribute,
+  CustomElement,
   ICustomElementViewModel,
   IHydratedController,
+  ISSRContext,
+  type ISSRScope,
   customElement,
 } from '@aurelia/runtime-html';
 import { tasksSettled } from '@aurelia/runtime';
-import {
-  assert, createFixture
-} from '@aurelia/testing';
+import { assert, createFixture, TestContext } from '@aurelia/testing';
 
 describe(`3-runtime-html/if.integration.spec.ts`, function () {
   class EventLog {
@@ -239,6 +242,272 @@ describe(`3-runtime-html/if.integration.spec.ts`, function () {
       void tearDown();
 
       assertText('');
+    });
+
+    describe('else structural association', function () {
+      const GapMarker = CustomAttribute.define('else-gap-marker', class {});
+
+      @customElement({ name: 'else-gap-element', template: 'gap' })
+      class GapElement {}
+
+      const invalidGaps: readonly {
+        name: string;
+        markup: string;
+        dependencies?: unknown[];
+        value?: string;
+      }[] = [
+        { name: 'significant text', markup: 'gap' },
+        { name: 'a non-breaking space', markup: '\u00a0' },
+        { name: 'an interpolation', markup: '${value}' },
+        { name: 'an initially empty interpolation', markup: '${value}', value: '' },
+        { name: 'a let element', markup: '<let gap.bind="value"></let>' },
+        { name: 'a local template declaration', markup: '<template as-custom-element="else-gap-local">gap</template>' },
+        { name: 'a plain element', markup: '<p>gap</p>' },
+        { name: 'an element with an unregistered attribute', markup: '<p else-gap-marker>gap</p>' },
+        { name: 'a registered custom attribute', markup: '<p else-gap-marker>gap</p>', dependencies: [GapMarker] },
+        { name: 'an unregistered custom element', markup: '<else-gap-element></else-gap-element>' },
+        { name: 'a registered custom element', markup: '<else-gap-element></else-gap-element>', dependencies: [GapElement] },
+        { name: 'another template controller', markup: '<p repeat.for="i of 1">gap</p>' },
+        { name: 'a plain template', markup: '<template>gap</template>' },
+      ];
+
+      for (const { name, markup, dependencies, value = 'value' } of invalidGaps) {
+        it(`rejects else after ${name}`, function () {
+          assert.throws(() => createFixture(
+            `<div if.bind="condition">if</div>${markup}<div else>else</div>`,
+            { condition: false, value },
+            dependencies,
+          ), /AUR0810/);
+        });
+      }
+
+      it('rejects else without a preceding sibling', function () {
+        assert.throws(() => createFixture('<div else>else</div>'), /AUR0810/);
+      });
+
+      it('allows formatting whitespace and comments between if and else', function () {
+        const { appHost, component } = createFixture(
+          '<div if.bind="condition">if</div>\n  <!-- formatting -->\n  <div else>else</div>',
+          { condition: true },
+        );
+
+        assert.strictEqual(appHost.textContent!.trim(), 'if');
+        component.condition = false;
+        assert.strictEqual(appHost.textContent!.trim(), 'else');
+      });
+
+      it('associates adjacent branches through preserved SSR markers', async function () {
+        class App {
+          public show = false;
+        }
+
+        const AppElement = CustomElement.define({
+          name: 'ssr-adjacent-if-else',
+          template: [
+            '<div if.bind="show" data-branch="if">if</div>',
+            '\n  <!-- formatting -->\n  ',
+            '<div else data-branch="else">else</div>',
+          ].join(''),
+        }, App);
+
+        const serverContext = TestContext.create();
+        serverContext.container.register(
+          Registration.instance(ISSRContext, { preserveMarkers: true }),
+        );
+        const serverHost = serverContext.doc.body.appendChild(
+          serverContext.createElement('ssr-adjacent-if-else'),
+        );
+        const serverAu = new Aurelia(serverContext.container).app({
+          host: serverHost,
+          component: AppElement,
+        });
+
+        let markup: string;
+        try {
+          await serverAu.start();
+          markup = serverHost.innerHTML;
+          assert.strictEqual(serverHost.textContent!.trim(), 'else');
+          assert.strictEqual(
+            (markup.match(/<!--au-->/g) ?? []).length,
+            2,
+            'server rendering preserves the target marker for each branch',
+          );
+        } finally {
+          await serverAu.stop(true);
+          serverAu.dispose();
+          serverHost.remove();
+        }
+
+        const clientContext = TestContext.create();
+        const clientHost = clientContext.doc.body.appendChild(
+          clientContext.createElement('ssr-adjacent-if-else'),
+        );
+        clientHost.innerHTML = markup;
+        const serverElse = clientHost.querySelector('[data-branch="else"]');
+        assert.notStrictEqual(serverElse, null);
+
+        const ssrScope: ISSRScope = {
+          name: 'ssr-adjacent-if-else',
+          children: [{
+            type: 'if',
+            state: { value: false },
+            views: [{ nodeCount: 1, children: [] }],
+          }],
+        };
+        const clientAu = new Aurelia(clientContext.container);
+        try {
+          const root = await clientAu.hydrate({
+            host: clientHost,
+            component: AppElement,
+            ssrScope,
+          });
+          try {
+            const component = root.controller.viewModel as App;
+            assert.strictEqual(
+              clientHost.querySelector('[data-branch="else"]'),
+              serverElse,
+              'the server-rendered else branch is adopted',
+            );
+
+            component.show = true;
+            await tasksSettled();
+            assert.strictEqual(clientHost.textContent!.trim(), 'if');
+
+            component.show = false;
+            await tasksSettled();
+            assert.strictEqual(clientHost.textContent!.trim(), 'else');
+            assert.strictEqual(
+              clientHost.querySelector('[data-branch="else"]'),
+              serverElse,
+              'the adopted cached else view is reused',
+            );
+          } finally {
+            await root.deactivate();
+            root.dispose();
+          }
+        } finally {
+          clientAu.dispose();
+          clientHost.remove();
+        }
+      });
+
+      it('does not let a nested if in an intervening element claim the outer else', function () {
+        assert.throws(() => createFixture(
+          [
+            '<div if.bind="outer">outer-if</div>',
+            '<section><span if.bind="inner">inner-if</span></section>',
+            '<div else>outer-else</div>',
+          ].join(''),
+          { outer: true, inner: false },
+        ), /AUR0810/);
+      });
+
+      it('keeps adjacent conditional pairs independent', function () {
+        const { assertText, component } = createFixture(
+          [
+            '<div if.bind="first">a</div>',
+            '<div else>b</div>',
+            '<div if.bind="second">c</div>',
+            '<div else>d</div>',
+          ].join(''),
+          { first: true, second: false },
+        );
+
+        assertText('ad');
+        component.first = false;
+        component.second = true;
+        assertText('bc');
+      });
+
+      it('associates projected branches within the same slot', function () {
+        @customElement({
+          name: 'else-slot-host',
+          template: '<au-slot name="content"></au-slot>',
+        })
+        class SlotHost {}
+
+        const { assertText, component } = createFixture(
+          [
+            '<else-slot-host>',
+            '<div au-slot="content" if.bind="condition">if</div>',
+            '<div au-slot="content" else>else</div>',
+            '</else-slot-host>',
+          ].join(''),
+          { condition: true },
+          [SlotHost],
+        );
+
+        assertText('if');
+        component.condition = false;
+        assertText('else');
+      });
+
+      it('rejects projected branches from different slots with AUR0810', function () {
+        @customElement({
+          name: 'else-multi-slot-host',
+          template: '<au-slot name="first"></au-slot><au-slot name="second"></au-slot>',
+        })
+        class MultiSlotHost {}
+
+        assert.throws(() => createFixture(
+          [
+            '<else-multi-slot-host>',
+            '<div au-slot="first" if.bind="condition">if</div>',
+            '<div au-slot="second" else>else</div>',
+            '</else-multi-slot-host>',
+          ].join(''),
+          { condition: false },
+          [MultiSlotHost],
+        ), /AUR0810/);
+      });
+
+      it('does not join branches unwrapped from separate projection templates', function () {
+        @customElement({
+          name: 'else-template-slot-host',
+          template: '<au-slot name="content"></au-slot>',
+        })
+        class TemplateSlotHost {}
+
+        assert.throws(() => createFixture(
+          [
+            '<else-template-slot-host>',
+            '<template au-slot="content"><div if.bind="condition">if</div></template>',
+            '<template au-slot="content"><div else>else</div></template>',
+            '</else-template-slot-host>',
+          ].join(''),
+          { condition: false },
+          [TemplateSlotHost],
+        ), /AUR0810/);
+      });
+
+      it('associates each repeated pair within its own view', async function () {
+        const { assertText, component } = createFixture(
+          [
+            '<div repeat.for="item of items">',
+            '<span if.bind="item.visible">${item.name}-if</span>',
+            '<span else>${item.name}-else</span>',
+            '</div>',
+          ].join(''),
+          {
+            items: [
+              { name: 'a', visible: true },
+              { name: 'b', visible: false },
+            ],
+          },
+        );
+
+        assertText('a-ifb-else');
+        component.items[1].visible = true;
+        assertText('a-ifb-if');
+
+        component.items.unshift({ name: 'c', visible: false });
+        await tasksSettled();
+        assertText('c-elsea-ifb-if');
+
+        component.items.splice(1, 1);
+        await tasksSettled();
+        assertText('c-elseb-if');
+      });
     });
 
     {

--- a/packages/__tests__/src/3-runtime-html/ssr-hydration.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/ssr-hydration.spec.ts
@@ -1,4 +1,5 @@
 import { DI, IContainer } from '@aurelia/kernel';
+import { createAccessScopeExpression } from '@aurelia/expression-parser';
 import {
   IRenderLocation,
   type ISSRScope,
@@ -10,13 +11,126 @@ import {
   CustomElementDefinition,
   isSSRTemplateController,
   isSSRScope,
+  hydrateSSRDefinition,
 } from '@aurelia/runtime-html';
 import {
+  BindingMode,
+  itHydrateTemplateController,
+  itPropertyBinding,
+  type HydrateTemplateController,
+  type PropertyBindingInstruction,
+} from '@aurelia/template-compiler';
+import {
   assert,
+  createFixture,
   TestContext,
 } from '@aurelia/testing';
 
 describe('3-runtime-html/ssr-hydration.spec.ts', function () {
+  it('preserves and executes template-controller source provenance in serialized definitions', async function () {
+    const hydrated = hydrateSSRDefinition({
+      template: '<!--au--><!--au-start--><!--au-end--><!--au--><!--au-start--><!--au-end-->',
+      expressions: [],
+      definition: {
+        name: 'app',
+        targetCount: 2,
+        instructions: [
+          [{
+            type: itHydrateTemplateController,
+            res: 'if',
+            templateIndex: 0,
+            instructions: [],
+            sourceNodeId: 1,
+          }],
+          [{
+            type: itHydrateTemplateController,
+            res: 'else',
+            templateIndex: 1,
+            instructions: [],
+            sourceNodeId: 2,
+            previousSignificantSiblingSourceNodeId: 1,
+          }],
+        ],
+        nestedTemplates: [
+          { name: 'if-view', targetCount: 0, instructions: [], nestedTemplates: [] },
+          { name: 'else-view', targetCount: 0, instructions: [], nestedTemplates: [] },
+        ],
+      },
+      nestedHtmlTree: [
+        { html: '<div>if</div>', nested: [] },
+        { html: '<div>else</div>', nested: [] },
+      ],
+    });
+    const ifInstruction = hydrated.instructions[0][0] as HydrateTemplateController;
+    const elseInstruction = hydrated.instructions[1][0] as HydrateTemplateController;
+
+    assert.strictEqual(ifInstruction.sourceNodeId, 1);
+    assert.strictEqual(elseInstruction.sourceNodeId, 2);
+    assert.strictEqual(elseInstruction.previousSignificantSiblingSourceNodeId, 1);
+
+    const conditionBinding: PropertyBindingInstruction = {
+      type: itPropertyBinding,
+      from: createAccessScopeExpression('show'),
+      to: 'value',
+      mode: BindingMode.toView,
+    };
+    ifInstruction.props.push(conditionBinding);
+    const { assertText, component, tearDown } = createFixture(
+      hydrated.template,
+      { show: false },
+      [],
+      true,
+      TestContext.create(),
+      {},
+      hydrated,
+    );
+
+    assertText('else');
+    component.show = true;
+    assertText('if');
+    await tearDown();
+
+    const mutableIfInstruction = ifInstruction as { sourceNodeId?: number };
+    const mutableElseInstruction = elseInstruction as {
+      sourceNodeId?: number;
+      previousSignificantSiblingSourceNodeId?: number;
+    };
+    delete mutableElseInstruction.sourceNodeId;
+    assert.throws(() => createFixture(
+      hydrated.template,
+      { show: false },
+      [],
+      true,
+      TestContext.create(),
+      {},
+      hydrated,
+    ), /AUR0810/, 'mixed source provenance fails closed');
+
+    delete mutableIfInstruction.sourceNodeId;
+    assert.throws(() => createFixture(
+      hydrated.template,
+      { show: false },
+      [],
+      true,
+      TestContext.create(),
+      {},
+      hydrated,
+    ), /AUR0810/, 'dangling predecessor provenance fails closed');
+
+    delete mutableElseInstruction.previousSignificantSiblingSourceNodeId;
+    const legacyFixture = createFixture(
+      hydrated.template,
+      { show: false },
+      [],
+      true,
+      TestContext.create(),
+      {},
+      hydrated,
+    );
+    legacyFixture.assertText('else');
+    await legacyFixture.tearDown();
+  });
+
   /**
    * Creates a render location (au-start/au-end comment pair) with
    * pre-populated child nodes between them.

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -1235,6 +1235,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
         );
         verifyBindingInstructionsEqual(result.instructions[0][0], {
           type: itHydrateTemplateController,
+          sourceNodeId: 0,
           res: CustomAttribute.getDefinition(TemplateControllerAttr),
           props: [createInterpolation({ from: '${hey}', to: 'value' })],
           def: {
@@ -1279,6 +1280,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
           type: 'custom-element',
           instructions: [[{
             type: itHydrateTemplateController,
+            sourceNodeId: 0,
             res: CustomAttribute.getDefinition(Foo),
             props: [],
             def: {
@@ -1287,6 +1289,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
               template: '<template><div><!--au--><!--au-start--><!--au-end--></div></template>',
               instructions: [[{
                 type: itHydrateTemplateController,
+                sourceNodeId: 1,
                 res: CustomAttribute.getDefinition(Bar),
                 props: [],
                 def: {
@@ -1296,6 +1299,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                   type: 'custom-element',
                   instructions: [[{
                     type: itHydrateTemplateController,
+                    sourceNodeId: 2,
                     res: CustomAttribute.getDefinition(Baz),
                     props: [],
                     def: {
@@ -1305,6 +1309,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                       type: 'custom-element',
                       instructions: [[{
                         type: itHydrateTemplateController,
+                        sourceNodeId: 3,
                         res: CustomAttribute.getDefinition(Qux),
                         props: [],
                         def: {
@@ -1353,6 +1358,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
             type: 'custom-element',
             instructions: [[{
               type: itHydrateTemplateController,
+              sourceNodeId: 0,
               res: resolveResources ? CustomAttribute.getDefinition(Foo) : 'foo',
               props: [],
               def: {
@@ -1362,6 +1368,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                 type: 'custom-element',
                 instructions: [[{
                   type: itHydrateTemplateController,
+                  sourceNodeId: 0,
                   res: resolveResources ? CustomAttribute.getDefinition(Bar) : 'bar',
                   props: [createIterateProp('i of ii', 'value', [])],
                   def: {
@@ -1371,6 +1378,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                     type: 'custom-element',
                     instructions: [[{
                       type: itHydrateTemplateController,
+                      sourceNodeId: 0,
                       res: resolveResources ? CustomAttribute.getDefinition(Baz) : 'baz',
                       props: [],
                       def: {
@@ -1380,6 +1388,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                         type: 'custom-element',
                         instructions: [[{
                           type: itHydrateTemplateController,
+                          sourceNodeId: 1,
                           res: resolveResources ? CustomAttribute.getDefinition(Qux) : 'qux',
                           props: [createIterateProp('i of ii', 'value', [])],
                           def: {
@@ -1389,6 +1398,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                             type: 'custom-element',
                             instructions: [[{
                               type: itHydrateTemplateController,
+                              sourceNodeId: 1,
                               res: resolveResources ? CustomAttribute.getDefinition(Quux) : 'quux',
                               props: [],
                               def: {
@@ -1430,6 +1440,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
             type: 'custom-element',
             instructions: [[{
               type: itHydrateTemplateController,
+              sourceNodeId: 0,
               res: resolveResources ? CustomAttribute.getDefinition(Foo) : 'foo',
               props: [],
               def: {
@@ -1439,6 +1450,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                 type: 'custom-element',
                 instructions: [[{
                   type: itHydrateTemplateController,
+                  sourceNodeId: 0,
                   res: resolveResources ? CustomAttribute.getDefinition(Bar) : 'bar',
                   props: [createIterateProp('i of ii', 'value', [])],
                   def: {
@@ -1448,6 +1460,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                     type: 'custom-element',
                     instructions: [[{
                       type: itHydrateTemplateController,
+                      sourceNodeId: 0,
                       res: resolveResources ? CustomAttribute.getDefinition(Baz) : 'baz',
                       props: [],
                       def: {
@@ -1457,6 +1470,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                         type: 'custom-element',
                         instructions: [[{
                           type: itHydrateTemplateController,
+                          sourceNodeId: 1,
                           res: resolveResources ? CustomAttribute.getDefinition(Qux) : 'qux',
                           props: [createIterateProp('i of ii', 'value', [])],
                           def: {
@@ -1466,6 +1480,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                             type: 'custom-element',
                             instructions: [[{
                               type: itHydrateTemplateController,
+                              sourceNodeId: 1,
                               res: resolveResources ? CustomAttribute.getDefinition(Quux) : 'quux',
                               props: [],
                               def: {
@@ -1494,6 +1509,22 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
       const Bar = CustomAttribute.define({ name: 'bar', isTemplateController: true }, class Bar { });
       const Baz = CustomAttribute.define({ name: 'baz', isTemplateController: true }, class Baz { });
 
+      it('records significant source siblings before compilation removes them', function () {
+        const { result } = compileTemplate(
+          '<div foo></div>\n<!-- formatting --><div bar></div>${value}<div foo></div>',
+          Foo,
+          Bar,
+        );
+        const first = result.instructions[0][0] as HydrateTemplateController;
+        const second = result.instructions[1][0] as HydrateTemplateController;
+        const afterInterpolation = result.instructions[3][0] as HydrateTemplateController;
+
+        assert.strictEqual(typeof first.sourceNodeId, 'number');
+        assert.strictEqual(second.previousSignificantSiblingSourceNodeId, first.sourceNodeId);
+        assert.strictEqual(typeof afterInterpolation.previousSignificantSiblingSourceNodeId, 'number');
+        assert.notStrictEqual(afterInterpolation.previousSignificantSiblingSourceNodeId, second.sourceNodeId);
+      });
+
       for (const [otherAttrPosition, appTemplate] of [
         ['before', '<div a.bind="b" foo bar>'],
         ['middle', '<div foo a.bind="b" bar>'],
@@ -1506,6 +1537,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
             template: '<template><!--au--><!--au-start--><!--au-end--></template>',
             instructions: [[{
               type: itHydrateTemplateController,
+              sourceNodeId: 0,
               res: CustomAttribute.getDefinition(Foo),
               props: [],
               def: {
@@ -1515,6 +1547,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                 type: 'custom-element',
                 instructions: [[{
                   type: itHydrateTemplateController,
+                  sourceNodeId: 0,
                   res: CustomAttribute.getDefinition(Bar),
                   props: [],
                   def: {
@@ -1545,6 +1578,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
             // for foo=""
             name: 'unamed',
             type: itHydrateTemplateController,
+            sourceNodeId: 1,
             res: CustomAttribute.getDefinition(Foo),
             props: [],
             def: {
@@ -1555,6 +1589,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
               instructions: [[{
                 // for bar.for
                 type: itHydrateTemplateController,
+                sourceNodeId: 1,
                 res: CustomAttribute.getDefinition(Bar),
                 props: [createIterateProp('i of ii', 'value', [])],
                 def: {
@@ -1564,6 +1599,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                   template: '<template><!--au--><!--au-start--><!--au-end--></template>',
                   instructions: [[{
                     type: itHydrateTemplateController,
+                    sourceNodeId: 1,
                     res: CustomAttribute.getDefinition(Baz),
                     props: [createPropBinding({ from: 'e', to: 'value' })],
                     def: {
@@ -1595,6 +1631,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
             // for foo=""
             name: 'unamed',
             type: itHydrateTemplateController,
+            sourceNodeId: 1,
             res: CustomAttribute.getDefinition(Foo),
             props: [],
             def: {
@@ -1606,6 +1643,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                 // for bar.for
                 name: 'unamed',
                 type: itHydrateTemplateController,
+                sourceNodeId: 1,
                 res: CustomAttribute.getDefinition(Bar),
                 props: [createIterateProp('i of ii', 'value', [])],
                 def: {
@@ -1616,6 +1654,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
                   instructions: [[{
                     name: 'unamed',
                     type: itHydrateTemplateController,
+                    sourceNodeId: 1,
                     res: CustomAttribute.getDefinition(Baz),
                     props: [createPropBinding({ from: 'e', to: 'value', mode: 2 })],
                     def: {

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -21,6 +21,8 @@ export const IEventTarget = /*@__PURE__*/createInterface<IEventTarget>('IEventTa
 export const IRenderLocation = /*@__PURE__*/createInterface<IRenderLocation>('IRenderLocation');
 export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
   $start?: IRenderLocation<T>;
+  /** Compiler source-node identity used by structurally linked template controllers. */
+  $sourceNodeId?: number;
   /** Target index for SSR hydration manifest lookup */
   $targetIndex?: number;
 };

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -372,6 +372,7 @@ export const TemplateControllerRenderer = /*@__PURE__*/ renderer(class TemplateC
         : ctxContainer
     );
     const renderLocation = convertToRenderLocation(target);
+    renderLocation.$sourceNodeId = instruction.sourceNodeId;
 
     const results = invokeAttribute(
       /* platform         */platform,

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import { onResolve, resolve } from '@aurelia/kernel';
-import { IRenderLocation } from '../../dom';
+import { IRenderLocation, isRenderLocation } from '../../dom';
 import { IViewFactory } from '../../templating/view';
 import { IPlatform } from '../../platform';
 
 import type { ISyntheticView, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ControllerVisitor, IHydratableController } from '../../templating/controller';
-import type { IInstruction } from '@aurelia/template-compiler';
+import { isHTMLWhitespace, type HydrateTemplateController, type IInstruction } from '@aurelia/template-compiler';
 import type { INode } from '../../dom.node';
 import { ErrorNames, createMappedError } from '../../errors';
-import { CustomAttributeStaticAuDefinition, attrTypeName } from '../custom-attribute';
+import { CustomAttribute, CustomAttributeStaticAuDefinition, attrTypeName } from '../custom-attribute';
 import { isSSRTemplateController, adoptSSRView, type ISSRTemplateController } from '../../templating/ssr';
 
 export class If implements ICustomAttributeViewModel {
@@ -194,19 +194,59 @@ export class Else implements ICustomAttributeViewModel {
   /** @internal */ private readonly _factory = resolve(IViewFactory);
 
   public link(
-    controller: IHydratableController,
+    _controller: IHydratableController,
     _childController: ICustomAttributeController,
     _target: INode,
     _instruction: IInstruction,
   ): void {
-    const children = controller.children!;
-    const ifBehavior: If | ICustomAttributeController = children[children.length - 1] as If | ICustomAttributeController;
-    if (ifBehavior instanceof If) {
-      ifBehavior.elseFactory = this._factory;
-    } else if (ifBehavior.viewModel instanceof If) {
-      ifBehavior.viewModel.elseFactory = this._factory;
-    } else {
+    const instruction = _instruction as HydrateTemplateController;
+    const ifController = findPreviousIf(
+      _target as IRenderLocation,
+      instruction.sourceNodeId,
+      instruction.previousSignificantSiblingSourceNodeId,
+    );
+    if (!(ifController?.viewModel instanceof If)) {
       throw createMappedError(ErrorNames.else_without_if);
     }
+    ifController.viewModel.elseFactory = this._factory;
   }
 }
+
+/**
+ * Template controllers are represented by `au-start`/`au-end` marker pairs.
+ * Use those markers to preserve authored sibling structure: the controller list
+ * does not contain ordinary DOM nodes and therefore cannot establish adjacency.
+ * Source-node metadata retains the same boundary when compilation removes a
+ * target, such as an interpolation or `let` element, before linking.
+ */
+const findPreviousIf = (
+  location: IRenderLocation,
+  sourceNodeId: number | undefined,
+  previousSignificantSiblingSourceNodeId: number | undefined,
+): ICustomAttributeController<If> | undefined => {
+  let node = location.$start?.previousSibling ?? null;
+  while (node !== null) {
+    if (isRenderLocation(node)) {
+      const previousSourceNodeId = node.$sourceNodeId;
+      const hasSource = sourceNodeId !== void 0;
+      const hasPreviousSiblingSource = previousSignificantSiblingSourceNodeId !== void 0;
+      const previousHasSource = previousSourceNodeId !== void 0;
+      if (
+        hasSource !== hasPreviousSiblingSource
+        || hasSource !== previousHasSource
+        || (hasSource && previousSignificantSiblingSourceNodeId !== previousSourceNodeId)
+      ) {
+        return;
+      }
+      return CustomAttribute.for<If>(node, 'if');
+    }
+    if (node.nodeType === 3 /* Text */) {
+      if (!isHTMLWhitespace((node as Text).data)) {
+        return;
+      }
+    } else if (node.nodeType !== 8 /* Comment */) {
+      return;
+    }
+    node = node.previousSibling;
+  }
+};

--- a/packages/runtime-html/src/templating/ssr.ts
+++ b/packages/runtime-html/src/templating/ssr.ts
@@ -222,7 +222,14 @@ type SerializedInstruction =
   | { type: typeof itSetAttribute; value: string; to: string }
   | { type: typeof itHydrateElement; res: string; instructions: SerializedInstruction[]; containerless?: boolean }
   | { type: typeof itHydrateAttribute; res: string; alias?: string; instructions: SerializedInstruction[] }
-  | { type: typeof itHydrateTemplateController; res: string; templateIndex: number; instructions: SerializedInstruction[] }
+  | {
+    type: typeof itHydrateTemplateController;
+    res: string;
+    templateIndex: number;
+    instructions: SerializedInstruction[];
+    sourceNodeId?: number;
+    previousSignificantSiblingSourceNodeId?: number;
+  }
   | { type: typeof itHydrateLetElement; bindings: { exprId: ExprId; to: string }[]; toBindingContext: boolean }
   | { type: typeof itIteratorBinding; exprId: ExprId; to: string; aux?: { exprId: ExprId; name: string }[] };
 
@@ -437,6 +444,8 @@ function translateInstruction(ins: SerializedInstruction, ctx: TranslationContex
         def,
         res: ins.res,
         alias: void 0,
+        sourceNodeId: ins.sourceNodeId,
+        previousSignificantSiblingSourceNodeId: ins.previousSignificantSiblingSourceNodeId,
         props,
       };
       return instruction;

--- a/packages/template-compiler/src/index.ts
+++ b/packages/template-compiler/src/index.ts
@@ -82,6 +82,10 @@ export {
 } from './template-element-factory';
 
 export {
+  isHTMLWhitespace,
+} from './utilities-dom';
+
+export {
   type AttributeBindingInstruction,
   type HydrateAttributeInstruction,
   type HydrateElementInstruction,

--- a/packages/template-compiler/src/instructions.ts
+++ b/packages/template-compiler/src/instructions.ts
@@ -155,6 +155,18 @@ export interface HydrateTemplateController<T extends IAttributeComponentDefiniti
   readonly res: string | /* Constructable | */ T;
   readonly alias: string | undefined;
   /**
+   * Compiler/runtime coordination metadata identifying the significant source
+   * node that produced this instruction. Template controllers on the same
+   * element share an id; formatting whitespace and comments do not consume one.
+   * IDs are unique across the complete compiled root, including its nested
+   * templates and projections.
+   * Compiler-generated instructions include this metadata, while legacy or
+   * hand-authored instructions may omit it.
+   */
+  readonly sourceNodeId?: number;
+  /** Identity of the previous significant sibling source node, when available. */
+  readonly previousSignificantSiblingSourceNodeId?: number;
+  /**
    * Bindable instructions for the template controller instance
    */
   readonly props: IInstruction[];

--- a/packages/template-compiler/src/template-compiler.ts
+++ b/packages/template-compiler/src/template-compiler.ts
@@ -59,7 +59,7 @@ import {
 import { AttrSyntax, IAttributeParser } from './attribute-pattern';
 import { BindingCommand, BindingCommandInstance } from './binding-command';
 import { etInterpolation, etIsProperty, tcObjectFreeze, tcCreateInterface, singletonRegistration, definitionTypeElement } from './utilities';
-import { auLocationStart, auLocationEnd, appendManyToTemplate, appendToTemplate, insertBefore, insertManyBefore, isElement, isTextNode } from './utilities-dom';
+import { auLocationStart, auLocationEnd, appendManyToTemplate, appendToTemplate, insertBefore, insertManyBefore, isElement, isHTMLWhitespace, isTextNode } from './utilities-dom';
 
 import type {
   IContainer,
@@ -136,6 +136,9 @@ export class TemplateCompiler implements ITemplateCompiler {
     if (template.hasAttribute(localTemplateIdentifier)) {
       throw createMappedError(ErrorNames.compiler_root_is_local, definition);
     }
+    // Capture authored sibling order before local-template extraction and the
+    // normal compilation passes replace or remove source nodes.
+    context._recordSourceSiblingOrder(content);
     this._compileLocalElement(content, context);
     this._compileNode(content, context);
 
@@ -367,6 +370,7 @@ export class TemplateCompiler implements ITemplateCompiler {
   // and it should return the next node to be compiled
   /** @internal */
   private _compileNode(node: Node, context: CompilationContext): Node | null {
+    context._recordSourceNode(node);
     switch (node.nodeType) {
       case 1:
         switch (node.nodeName) {
@@ -388,6 +392,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       case 3:
         return this._compileText(node as Text, context);
       case 11: {
+        context._recordSourceSiblingOrder(node);
         let current: Node | null = (node as DocumentFragment).firstChild;
         while (current !== null) {
           current = this._compileNode(current, context);
@@ -502,6 +507,9 @@ export class TemplateCompiler implements ITemplateCompiler {
     const elementMetadata: Record<PropertyKey, unknown> = {};
     if (isCustomElement) {
       processContentResult = elDef.processContent?.call(elDef.Type, el as HTMLElement, context.p, elementMetadata);
+    }
+    if (isCustomElement && processContentResult !== false) {
+      context._recordSourceSiblingOrder(el.nodeName === TEMPLATE_NODE_NAME ? (el as HTMLTemplateElement).content : el);
     }
 
     // 1. Classify all attributes
@@ -921,6 +929,8 @@ export class TemplateCompiler implements ITemplateCompiler {
             def: voidDefinition,
             res: this.resolveResources ? attrDef : attrDef.name,
             alias: void 0,
+            sourceNodeId: context._getSourceNodeId(el),
+            previousSignificantSiblingSourceNodeId: context._getPreviousSignificantSiblingSourceNodeId(el),
             props: attrBindableInstructions,
           } satisfies HydrateTemplateController);
         } else {
@@ -1398,6 +1408,9 @@ export class TemplateCompiler implements ITemplateCompiler {
 
     // Walk through child nodes, extracting those with [au-slot]
     while (child !== null) {
+      if (child.nodeName === TEMPLATE_NODE_NAME) {
+        context._recordSourceSiblingOrder((child as HTMLTemplateElement).content);
+      }
       targetSlot = isElement(child) ? child.getAttribute(auslotAttr) : null;
       hasAuSlot = targetSlot !== null || isCustomElement && !isShadowDom;
       childEl = child.nextSibling as Element;
@@ -1476,6 +1489,14 @@ const TEMPLATE_NODE_NAME = 'TEMPLATE';
 const isMarker = (el: Node): el is Comment =>
   el.nodeType === 8 && (el as Comment).textContent === 'au';
 
+interface SourceOrder {
+  readonly nodeIds: WeakMap<Node, number>;
+  readonly previousSignificantSiblingNodeIds: WeakMap<Node, number>;
+  readonly lastSignificantSiblingNodeIds: WeakMap<Node, number>;
+  readonly recordedParents: WeakSet<Node>;
+  nextNodeId: number;
+}
+
 // this class is intended to be an implementation encapsulating the information at the root level of a template
 // this works at the time this is created because everything inside a template should be retrieved
 // from the root itself.
@@ -1490,6 +1511,7 @@ class CompilationContext {
   public readonly _commandResolver: IBindingCommandResolver;
   public readonly _templateFactory: ITemplateElementFactory;
   public readonly _logger: ILogger;
+  private readonly _sourceOrder: SourceOrder;
   public readonly _attrParser: IAttributeParser;
   public readonly _attrMapper: IAttrMapper;
   public readonly _exprParser: IExpressionParser;
@@ -1512,6 +1534,15 @@ class CompilationContext {
     const hasParent = parent !== null;
     this.c = container;
     this.root = root === null ? this : root;
+    this._sourceOrder = hasParent
+      ? parent._sourceOrder
+      : {
+        nodeIds: new WeakMap(),
+        previousSignificantSiblingNodeIds: new WeakMap(),
+        lastSignificantSiblingNodeIds: new WeakMap(),
+        recordedParents: new WeakSet(),
+        nextNodeId: 0,
+      };
     this.def = def;
     this.parent = parent;
     this._resourceResolver = hasParent ? parent._resourceResolver : container.get(IResourceResolver);
@@ -1533,6 +1564,53 @@ class CompilationContext {
     (this.root.deps ??= []).push(Type);
     this.root.c.register(Type);
     return this;
+  }
+
+  /** Record significant source siblings before subsequent compilation steps mutate them. */
+  public _recordSourceSiblingOrder(parent: Node): void {
+    const sourceOrder = this._sourceOrder;
+    if (sourceOrder.recordedParents.has(parent)) {
+      return;
+    }
+    sourceOrder.recordedParents.add(parent);
+    let child = parent.firstChild;
+    while (child !== null) {
+      this._recordSourceNode(child);
+      child = child.nextSibling;
+    }
+  }
+
+  /** Record one node when its parent can be compiled without a structural prepass. */
+  public _recordSourceNode(node: Node): void {
+    if (
+      node.nodeType !== 1 /* Element */
+      && (node.nodeType !== 3 /* Text */ || isHTMLWhitespace((node as Text).data))
+    ) {
+      return;
+    }
+    const parent = node.parentNode;
+    if (parent === null) {
+      return;
+    }
+    const sourceOrder = this._sourceOrder;
+    let sourceNodeId = sourceOrder.nodeIds.get(node);
+    if (sourceNodeId === void 0) {
+      sourceNodeId = sourceOrder.nextNodeId++;
+      sourceOrder.nodeIds.set(node, sourceNodeId);
+      const previousSourceNodeId = sourceOrder.lastSignificantSiblingNodeIds.get(parent);
+      if (previousSourceNodeId !== void 0) {
+        sourceOrder.previousSignificantSiblingNodeIds.set(node, previousSourceNodeId);
+      }
+    }
+    sourceOrder.lastSignificantSiblingNodeIds.set(parent, sourceNodeId);
+  }
+
+  public _getSourceNodeId(node: Node): number | undefined {
+    return this._sourceOrder.nodeIds.get(node);
+  }
+
+  public _getPreviousSignificantSiblingSourceNodeId(node: Node): number | undefined {
+    return this._sourceOrder.previousSignificantSiblingNodeIds.get(node);
   }
 
   public _text(text: string) {

--- a/packages/template-compiler/src/utilities-dom.ts
+++ b/packages/template-compiler/src/utilities-dom.ts
@@ -45,3 +45,10 @@ export const isElement = (node: Node): node is Element => node.nodeType === 1;
 
 /** @internal */
 export const isTextNode = (node: Node): node is Text => node.nodeType === 3;
+
+const htmlWhitespace = /^[\t\n\f\r ]*$/;
+
+/** Whether a value contains only the five whitespace characters defined by HTML. */
+export const isHTMLWhitespace = (value: string): boolean => {
+  return htmlWhitespace.test(value);
+};


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

`else` is documented and generally understood as the alternative branch of the immediately preceding sibling `if`: two branches occupying one structural position.

Currently, Aurelia does not establish that relationship from template structure. `Else.link` selects the last controller registered under the parent. Because ordinary DOM nodes are absent from that controller list, this template is accepted:

```html
<div if.bind="condition">if</div>
<p>unrelated content</p>
<div else>else</div>
```

The `else` branch is then rendered at the `if` location, before the `<p>`. Registering a custom element or attribute on the intervening node can make otherwise identical markup throw AUR0810 instead. A nested `if` inside an intervening wrapper can even capture the outer `else`.

Consequently, the meaning of `else` currently depends on incidental implementation details:

- Whether an intervening node creates an Aurelia controller
- Which resources happen to be registered
- How the compiler lowers or removes intervening content
- The order in which controllers are linked

This is neither a stable feature nor a useful compatibility guarantee. Supporting non-adjacent branches would require deliberately specifying where the alternative branch renders and how it interacts with intervening bindings, controllers, projections, lifecycles, and animations. It should not emerge accidentally from a controller-array lookup.

## 💁 Your Solution

Associate `else` with the immediately preceding sibling `if` in both the authored template and the live render structure. Formatting whitespace and HTML comments remain allowed; any other sibling content ends the pair and produces AUR0810.

Checking the runtime DOM alone is insufficient because compilation can erase significant source structure:

```html
<div if.bind="condition">if</div>
${message}
<div else>else</div>
```

```html
<div if.bind="condition">if</div>
<let message.bind="value"></let>
<div else>else</div>
```

Interpolations become binding targets, `<let>` is removed, local-template declarations are extracted, and projection templates may be unwrapped. By the time `Else.link` runs, a marker-only implementation can no longer distinguish these cases from genuine adjacency.

The compiler therefore records generic source-node provenance on template-controller instructions:

- The source node that produced the instruction
- That node’s previous significant sibling
- One root-wide identity space covering nested templates and projections

The renderer carries the source identity to the render location. `Else.link` then requires both:

1. The preceding live render marker belongs to an `if` at the same DOM boundary.
2. That `if` is the exact previous significant sibling recorded by the compiler.

In language-design terms, the relationship is defined by the source template, not by whichever nodes happen to survive lowering. Lowering must preserve the semantics rather than become the semantics.

The provenance is resource-neutral and additive to the instruction contract; the template compiler does not contain an `if`/`else` special case. Framework-generated and serialized instructions preserve it. Legacy or hand-authored instruction sets with no provenance on either side retain marker-based compatibility, while partially populated provenance fails closed.

## ⚠️ Compatibility

This intentionally rejects templates that previously relied on intervening content between `if` and `else`. Although such templates happened to work in some cases, the behavior was registration-sensitive, could associate with the wrong conditional, and did not have well-defined branch-placement semantics.

Applications relying on it should move the intervening content outside the pair or express the alternative with an explicit `if.bind` condition.

Making this correction before GA gives Aurelia a compositional rule we can document and preserve. If non-adjacent conditional branches are ever supported, they should be introduced as an explicit feature with intentionally designed semantics.

## 📑 Test Plan

Added regression coverage for:

- Whitespace and comments
- Text, interpolations, `<let>`, and local-template declarations
- Registered and unregistered elements and attributes
- Nested conditional capture
- Repeat views and collection mutation
- Same-slot, cross-slot, and unwrapped projection content
- JIT SSR/hydration and serialized `needsCompile: false` definitions
- Complete, legacy, and partially populated provenance


## 📦 Changeset

- [x] Added a changeset

cc @bigopon - this should be either merged (or intentionally rejected) before #2453