### PR TITLE
fix(runtime-html): close view lifecycle ownership gaps

### DIFF
--- a/.changeset/quiet-views-retire.md
+++ b/.changeset/quiet-views-retire.md
@@ -1,0 +1,9 @@
+---
+"@aurelia/runtime-html": patch
+---
+
+Conditional views now clean up and recycle at their owning lifecycle boundary:
+
+- `if` branches with `cache: false` are disposed after they finish leaving, including views retained before caching is disabled.
+- Released synthetic views can return to configured `ViewFactory` caches after teardown.
+- Ancestor-owned lifecycle failures keep their public rejection without also producing an unhandled descendant Promise rejection.

--- a/docs/user-docs/templates/conditional-rendering.md
+++ b/docs/user-docs/templates/conditional-rendering.md
@@ -47,6 +47,8 @@ By default, `if.bind` caches views and view models for performance. Disable cach
 <custom-element if="value.bind: canShow; cache: false"></custom-element>
 ```
 
+With caching disabled, Aurelia deactivates and disposes a branch when a conditional change removes it. Returning to that branch creates a new view and view model.
+
 {% hint style="warning" %}
 **When to Use:** Use `if.bind` when elements change infrequently and you want to completely remove them from the DOM to save memory and improve performance.
 {% endhint %}

--- a/packages/__tests__/src/3-runtime-html/controller.descendant-rejection.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/controller.descendant-rejection.spec.ts
@@ -1,0 +1,171 @@
+import {
+  CustomElement,
+} from '@aurelia/runtime-html';
+import {
+  assert,
+  createFixture,
+} from '@aurelia/testing';
+
+class Deferred {
+  public readonly promise: Promise<void>;
+  public resolve!: () => void;
+  public reject!: (reason: unknown) => void;
+
+  public constructor() {
+    this.promise = new Promise<void>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+describe('3-runtime-html/controller.descendant-rejection.spec.ts', function () {
+  it('keeps a descendant rejection on the initiator boundary without a host-unhandled duplicate', async function () {
+    const activation = new Deferred();
+    const error = new Error('descendant activation failed');
+    const Child = CustomElement.define({ name: 'rejecting-descendant', template: 'child' }, class {
+      public attaching(): Promise<void> {
+        return activation.promise;
+      }
+    });
+    const fixture = createFixture(
+      '<rejecting-descendant></rejecting-descendant>',
+      class App {},
+      [Child],
+      false,
+    );
+    const unhandled = observeUnhandledRejections();
+
+    try {
+      const hookFailure = captureRejection(activation.promise);
+      const start = fixture.start();
+      assert.instanceOf(start, Promise);
+      const startFailure = captureRejection(start as Promise<void>);
+
+      activation.reject(error);
+
+      assert.strictEqual(await hookFailure, error, 'the application hook Promise keeps its original rejection');
+      assert.strictEqual(await startFailure, error, 'the initiator reports the original descendant error');
+      await waitForUnhandledRejection();
+      assert.deepStrictEqual(unhandled.reasons, []);
+      assert.strictEqual(fixture.torn, true);
+    } finally {
+      unhandled.dispose();
+    }
+  });
+
+  it('does not host-report a descendant rejection recovered by a value-driven if swap', async function () {
+    const activation = new Deferred();
+    const deactivationStarted = new Deferred();
+    const error = new Error('value-driven descendant activation failed');
+    const Child = CustomElement.define({ name: 'recovering-descendant', template: 'child' }, class {
+      public attaching(): Promise<void> {
+        return activation.promise;
+      }
+      public detaching(): void {
+        deactivationStarted.resolve();
+      }
+    });
+    const fixture = createFixture(
+      '<recovering-descendant if.bind="show"></recovering-descendant><span else>fallback</span>',
+      class App { public show = false; },
+      [Child],
+    );
+    const unhandled = observeUnhandledRejections();
+
+    try {
+      const hookFailure = captureRejection(activation.promise);
+      fixture.component.show = true;
+      activation.reject(error);
+
+      assert.strictEqual(await hookFailure, error);
+      await deactivationStarted.promise;
+      fixture.component.show = false;
+      assert.strictEqual(
+        await waitForMicrotasks(() => fixture.appHost.textContent === 'fallback'),
+        true,
+        'the owning if remains reusable after cleaning up the failed descendant',
+      );
+
+      await waitForUnhandledRejection();
+      assert.deepStrictEqual(unhandled.reasons, []);
+      await fixture.stop(true);
+    } finally {
+      unhandled.dispose();
+    }
+  });
+
+  it('keeps a descendant deactivation rejection on the stop boundary without a host-unhandled duplicate', async function () {
+    const deactivation = new Deferred();
+    const error = new Error('descendant deactivation failed');
+    const Child = CustomElement.define({ name: 'rejecting-detaching-descendant', template: 'child' }, class {
+      public detaching(): Promise<void> {
+        return deactivation.promise;
+      }
+    });
+    const fixture = createFixture(
+      '<rejecting-detaching-descendant></rejecting-detaching-descendant>',
+      class App {},
+      [Child],
+    );
+    const unhandled = observeUnhandledRejections();
+
+    try {
+      const hookFailure = captureRejection(deactivation.promise);
+      const stop = fixture.stop(true);
+      assert.instanceOf(stop, Promise);
+      const stopFailure = captureRejection(stop as Promise<void>);
+
+      deactivation.reject(error);
+
+      assert.strictEqual(await hookFailure, error, 'the application hook Promise keeps its original rejection');
+      assert.strictEqual(await stopFailure, error, 'the stop initiator reports the original descendant error');
+      await waitForUnhandledRejection();
+      assert.deepStrictEqual(unhandled.reasons, []);
+    } finally {
+      unhandled.dispose();
+      fixture.testHost.remove();
+    }
+  });
+});
+
+function observeUnhandledRejections(): { readonly reasons: unknown[]; readonly dispose: () => void } {
+  const reasons: unknown[] = [];
+  let dispose: () => void;
+
+  if (typeof process !== 'undefined' && typeof process.on === 'function') {
+    const handler = (reason: unknown): void => { reasons.push(reason); };
+    process.on('unhandledRejection', handler);
+    dispose = () => { process.off('unhandledRejection', handler); };
+  } else {
+    const handler = (event: PromiseRejectionEvent): void => {
+      reasons.push(event.reason);
+      event.preventDefault();
+    };
+    addEventListener('unhandledrejection', handler);
+    dispose = () => { removeEventListener('unhandledrejection', handler); };
+  }
+
+  return { reasons, dispose };
+}
+
+async function captureRejection(promise: Promise<void>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  assert.fail('Expected promise to reject');
+}
+
+async function waitForMicrotasks(predicate: () => boolean): Promise<boolean> {
+  for (let i = 0; i < 20 && !predicate(); ++i) {
+    await Promise.resolve();
+  }
+  return predicate();
+}
+
+function waitForUnhandledRejection(): Promise<void> {
+  // Chrome reports unhandled rejections on a later host turn than Node.
+  return new Promise(resolve => setTimeout(resolve, 50));
+}

--- a/packages/__tests__/src/3-runtime-html/controller.synthetic-view-release.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/controller.synthetic-view-release.spec.ts
@@ -1,0 +1,273 @@
+import { Scope } from '@aurelia/runtime';
+import {
+  CustomElement,
+  CustomElementDefinition,
+  type IHydratedController,
+  type IRenderLocation,
+  type ISyntheticView,
+  type IViewFactory,
+  Repeat,
+  ViewFactory,
+} from '@aurelia/runtime-html';
+import { assert, createFixture, TestContext } from '@aurelia/testing';
+
+class Deferred {
+  public readonly promise: Promise<void>;
+  public resolve!: () => void;
+
+  public constructor() {
+    this.promise = new Promise<void>(resolve => {
+      this.resolve = resolve;
+    });
+  }
+}
+
+describe('3-runtime-html/controller.synthetic-view-release.spec.ts', function () {
+  it('preserves release through direct synchronous synthetic-view deactivation', function () {
+    const ctx = TestContext.create();
+    const factory = new ViewFactory(
+      ctx.container,
+      CustomElementDefinition.create({ name: 'direct-release-view', template: 'view' }),
+    );
+    factory.setCacheSize(1, false);
+    const view = factory.create();
+    view.setHost(ctx.createElement('div'));
+    assert.strictEqual(view.activate(view, null, Scope.create({})), void 0);
+
+    view.release();
+    assert.strictEqual(view.deactivate(view, null), void 0);
+    assert.strictEqual(factory.create(), view);
+    view.dispose();
+  });
+
+  it('returns a synchronously deactivated released row to its ViewFactory', async function () {
+    let disposeCalls = 0;
+    class Row {
+      public item!: { id: number };
+      public dispose(): void { ++disposeCalls; }
+    }
+    const RowElement = CustomElement.define({
+      name: 'sync-released-row',
+      template: '${item.id}',
+      bindables: ['item'],
+    }, Row);
+    const fixture = createFixture(
+      '<sync-released-row repeat.for="item of items" item.bind="item"></sync-released-row>',
+      class App { public items = [{ id: 1 }]; },
+      [RowElement],
+    );
+    await fixture.started;
+    const repeat = findRepeat(fixture.au.root.controller);
+    const factory = getFactory(repeat);
+    factory.setCacheSize(1, false);
+    const originalView = repeat.views[0];
+    const originalRow = getRow<Row>(originalView);
+
+    fixture.component.items.splice(0, 1);
+    assert.strictEqual(repeat.views.length, 0);
+    assert.strictEqual(disposeCalls, 0, 'the factory owns the released view');
+
+    fixture.component.items.push({ id: 2 });
+    assert.strictEqual(repeat.views[0], originalView);
+    assert.strictEqual(getRow<Row>(repeat.views[0]), originalRow);
+    fixture.assertText('2');
+
+    await fixture.stop(true);
+    assert.strictEqual(disposeCalls, 1);
+  });
+
+  it('returns a released row only after asynchronous deactivation settles', async function () {
+    const gate = new Deferred();
+    let shouldBlock = true;
+    class Row {
+      public item!: { id: number };
+      public detaching(): void | Promise<void> {
+        if (shouldBlock) {
+          shouldBlock = false;
+          return gate.promise;
+        }
+      }
+    }
+    const RowElement = CustomElement.define({
+      name: 'async-released-row',
+      template: '${item.id}',
+      bindables: ['item'],
+    }, Row);
+    const fixture = createFixture(
+      '<async-released-row repeat.for="item of items" item.bind="item"></async-released-row>',
+      class App { public items = [{ id: 1 }]; },
+      [RowElement],
+    );
+    await fixture.started;
+    const repeat = findRepeat(fixture.au.root.controller);
+    const factory = getFactory(repeat);
+    factory.setCacheSize(1, false);
+    const originalView = repeat.views[0];
+
+    fixture.component.items.splice(0, 1);
+    fixture.component.items.push({ id: 2 });
+    assert.strictEqual(repeat.views.length, 0, 'the queued insertion waits for row teardown');
+
+    const reconciliation = getReconciliation(repeat);
+    assert.instanceOf(reconciliation, Promise);
+    gate.resolve();
+    await reconciliation;
+
+    assert.strictEqual(repeat.views[0], originalView);
+    fixture.assertText('2');
+    await fixture.stop(true);
+  });
+
+  it('preserves release while activation is still pending', async function () {
+    const gate = new Deferred();
+    let shouldBlock = true;
+    class Row {
+      public item!: { id: number };
+      public attaching(): void | Promise<void> {
+        if (this.item.id === 1 && shouldBlock) {
+          shouldBlock = false;
+          return gate.promise;
+        }
+      }
+    }
+    const RowElement = CustomElement.define({
+      name: 'activating-released-row',
+      template: '${item.id}',
+      bindables: ['item'],
+    }, Row);
+    const fixture = createFixture(
+      '<activating-released-row repeat.for="item of items" item.bind="item"></activating-released-row>',
+      class App { public items = [{ id: 0 }]; },
+      [RowElement],
+    );
+    await fixture.started;
+    const repeat = findRepeat(fixture.au.root.controller);
+    const { factory, location, scopes } = getInternals(repeat);
+    factory.setCacheSize(1, false);
+    fixture.component.items[0].id = 1;
+
+    const candidate = factory.create(repeat.$controller);
+    candidate.nodes!.link(location);
+    candidate.setLocation(location);
+    const activation = candidate.activate(candidate, repeat.$controller, scopes[0]);
+    assert.instanceOf(activation, Promise);
+
+    candidate.release();
+    const deactivation = candidate.deactivate(candidate, repeat.$controller);
+    assert.instanceOf(deactivation, Promise);
+    gate.resolve();
+    await activation;
+    await deactivation;
+
+    const reused = factory.create(repeat.$controller);
+    assert.strictEqual(reused, candidate);
+    reused.dispose();
+    await fixture.stop(true);
+  });
+
+  it('disposes a released row when ViewFactory caching is disabled', async function () {
+    let disposeCalls = 0;
+    class Row {
+      public item!: { id: number };
+      public dispose(): void { ++disposeCalls; }
+    }
+    const RowElement = CustomElement.define({
+      name: 'uncached-released-row',
+      template: '${item.id}',
+      bindables: ['item'],
+    }, Row);
+    const fixture = createFixture(
+      '<uncached-released-row repeat.for="item of items" item.bind="item"></uncached-released-row>',
+      class App { public items = [{ id: 1 }]; },
+      [RowElement],
+    );
+    await fixture.started;
+    const repeat = findRepeat(fixture.au.root.controller);
+    const originalView = repeat.views[0];
+    assert.strictEqual(getFactory(repeat).isCaching, false);
+
+    fixture.component.items.splice(0, 1);
+    assert.strictEqual(disposeCalls, 1);
+    fixture.component.items.push({ id: 2 });
+    assert.notStrictEqual(repeat.views[0], originalView);
+
+    await fixture.stop(true);
+    assert.strictEqual(disposeCalls, 2);
+  });
+
+  it('disposes overflow when the ViewFactory cache is full', async function () {
+    const disposed: number[] = [];
+    class Row {
+      public item!: { id: number };
+      public dispose(): void { disposed.push(this.item.id); }
+    }
+    const RowElement = CustomElement.define({
+      name: 'cache-full-released-row',
+      template: '${item.id}',
+      bindables: ['item'],
+    }, Row);
+    const fixture = createFixture(
+      '<cache-full-released-row repeat.for="item of items" item.bind="item"></cache-full-released-row>',
+      class App { public items = [{ id: 1 }, { id: 2 }]; },
+      [RowElement],
+    );
+    await fixture.started;
+    const repeat = findRepeat(fixture.au.root.controller);
+    const factory = getFactory(repeat);
+    factory.setCacheSize(1, false);
+    const originalViews = repeat.views.slice();
+
+    fixture.component.items.splice(0, 2);
+    assert.deepStrictEqual(disposed, [2]);
+
+    fixture.component.items.push({ id: 3 }, { id: 4 });
+    assert.strictEqual(repeat.views[0], originalViews[0]);
+    assert.notStrictEqual(repeat.views[1], originalViews[1]);
+    fixture.assertText('34');
+
+    await fixture.stop(true);
+    assert.deepStrictEqual(disposed.sort(), [2, 3, 4]);
+  });
+});
+
+function findRepeat(root: IHydratedController): Repeat {
+  let repeat: Repeat | undefined;
+  root.accept(controller => {
+    if (controller.viewModel instanceof Repeat) {
+      repeat = controller.viewModel;
+      return true;
+    }
+  });
+  assert.notStrictEqual(repeat, void 0);
+  return repeat!;
+}
+
+function getFactory(repeat: Repeat): IViewFactory {
+  return getInternals(repeat).factory;
+}
+
+function getInternals(repeat: Repeat): {
+  readonly factory: IViewFactory;
+  readonly location: IRenderLocation;
+  readonly scopes: Scope[];
+} {
+  const internals = repeat as unknown as {
+    readonly _factory: IViewFactory;
+    readonly _location: IRenderLocation;
+    readonly _scopes: Scope[];
+  };
+  return {
+    factory: internals._factory,
+    location: internals._location,
+    scopes: internals._scopes,
+  };
+}
+
+function getReconciliation(repeat: Repeat): Promise<void> | undefined {
+  return (repeat as unknown as { readonly _reconciliation?: { readonly promise?: Promise<void> } })
+    ._reconciliation?.promise;
+}
+
+function getRow<T>(view: ISyntheticView): T {
+  return (view.children![0] as unknown as { readonly viewModel: T }).viewModel;
+}

--- a/packages/__tests__/src/3-runtime-html/if-view-lifecycle.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/if-view-lifecycle.spec.ts
@@ -189,16 +189,24 @@ describe('3-runtime-html/if-view-lifecycle.spec.ts', function () {
     await tasksSettled();
     assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 1, elseCreated: 2, elseDisposed: 1 });
 
-    fixture.component.cache = false;
+    fixture.component.show = true;
     await tasksSettled();
-    await fixture.stop(false);
     assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 1, elseCreated: 2, elseDisposed: 1 });
 
-    await fixture.au.start();
+    fixture.component.cache = false;
+    await tasksSettled();
+    fixture.component.show = false;
+    await tasksSettled();
     assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 3, elseDisposed: 2 });
 
+    await fixture.stop(false);
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 3, elseDisposed: 2 });
+
+    await fixture.au.start();
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 4, elseDisposed: 3 });
+
     await fixture.stop(true);
-    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 3, elseDisposed: 3 });
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 4, elseDisposed: 4 });
   });
 
   it('disposes nested uncached ownership when its outer view retires', async function () {

--- a/packages/__tests__/src/3-runtime-html/if-view-lifecycle.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/if-view-lifecycle.spec.ts
@@ -1,0 +1,305 @@
+import { tasksSettled } from '@aurelia/runtime';
+import { CustomElement } from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+class Deferred {
+  public readonly promise: Promise<void>;
+  public resolve!: () => void;
+  public reject!: (reason?: unknown) => void;
+
+  public constructor() {
+    this.promise = new Promise<void>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+describe('3-runtime-html/if-view-lifecycle.spec.ts', function () {
+  it('disposes every uncached if and else view exactly once across restart', async function () {
+    const counts = {
+      ifCreated: 0,
+      ifDisposed: 0,
+      elseCreated: 0,
+      elseDisposed: 0,
+    };
+    const IfBranch = CustomElement.define({ name: 'uncached-if-branch', template: 'if' }, class {
+      public constructor() { counts.ifCreated++; }
+      public dispose(): void { counts.ifDisposed++; }
+    });
+    const ElseBranch = CustomElement.define({ name: 'uncached-else-branch', template: 'else' }, class {
+      public constructor() { counts.elseCreated++; }
+      public dispose(): void { counts.elseDisposed++; }
+    });
+    const fixture = createFixture(
+      '<uncached-if-branch if="value.bind: show; cache: false"></uncached-if-branch>'
+      + '<uncached-else-branch else></uncached-else-branch>',
+      class App { public show = true; },
+      [IfBranch, ElseBranch],
+    );
+    await fixture.started;
+
+    assert.deepStrictEqual(counts, { ifCreated: 1, ifDisposed: 0, elseCreated: 0, elseDisposed: 0 });
+
+    fixture.component.show = false;
+    await tasksSettled();
+    assert.deepStrictEqual(counts, { ifCreated: 1, ifDisposed: 1, elseCreated: 1, elseDisposed: 0 });
+
+    fixture.component.show = true;
+    await tasksSettled();
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 1, elseCreated: 1, elseDisposed: 1 });
+
+    fixture.component.show = false;
+    await tasksSettled();
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 2, elseDisposed: 1 });
+
+    await fixture.stop(false);
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 2, elseDisposed: 1 });
+
+    await fixture.au.start();
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 3, elseDisposed: 2 });
+
+    await fixture.stop(true);
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 3, elseDisposed: 3 });
+  });
+
+  it('waits for outgoing async detachment before disposal and replacement activation', async function () {
+    const detaching = new Deferred();
+    const replacementAttached = new Deferred();
+    const events: string[] = [];
+    const IfBranch = CustomElement.define({ name: 'async-uncached-if-branch', template: 'if' }, class {
+      public detaching(): Promise<void> {
+        events.push('if:detaching');
+        return detaching.promise.then(() => { events.push('if:detached'); });
+      }
+      public dispose(): void { events.push('if:dispose'); }
+    });
+    const ElseBranch = CustomElement.define({ name: 'async-uncached-else-branch', template: 'else' }, class {
+      public constructor() { events.push('else:create'); }
+      public attaching(): void {
+        events.push('else:attaching');
+        replacementAttached.resolve();
+      }
+    });
+    const fixture = createFixture(
+      '<async-uncached-if-branch if="value.bind: show; cache: false"></async-uncached-if-branch>'
+      + '<async-uncached-else-branch else></async-uncached-else-branch>',
+      class App { public show = true; },
+      [IfBranch, ElseBranch],
+    );
+    await fixture.started;
+
+    fixture.component.show = false;
+    fixture.component.show = true;
+    fixture.component.show = false;
+    assert.deepStrictEqual(events, ['if:detaching']);
+    assert.strictEqual(fixture.appHost.textContent, 'if');
+
+    detaching.resolve();
+    await replacementAttached.promise;
+    assert.deepStrictEqual(events, [
+      'if:detaching',
+      'if:detached',
+      'if:dispose',
+      'else:create',
+      'else:attaching',
+    ]);
+    assert.strictEqual(fixture.appHost.textContent, 'else');
+
+    await fixture.stop(true);
+  });
+
+  it('keeps cached views reusable until final disposal', async function () {
+    const counts = {
+      ifCreated: 0,
+      ifDisposed: 0,
+      elseCreated: 0,
+      elseDisposed: 0,
+    };
+    const IfBranch = CustomElement.define({ name: 'cached-if-branch', template: 'if' }, class {
+      public constructor() { counts.ifCreated++; }
+      public dispose(): void { counts.ifDisposed++; }
+    });
+    const ElseBranch = CustomElement.define({ name: 'cached-else-branch', template: 'else' }, class {
+      public constructor() { counts.elseCreated++; }
+      public dispose(): void { counts.elseDisposed++; }
+    });
+    const fixture = createFixture(
+      '<cached-if-branch if.bind="show"></cached-if-branch><cached-else-branch else></cached-else-branch>',
+      class App { public show = true; },
+      [IfBranch, ElseBranch],
+    );
+    await fixture.started;
+
+    fixture.component.show = false;
+    await tasksSettled();
+    fixture.component.show = true;
+    await tasksSettled();
+    fixture.component.show = false;
+    await tasksSettled();
+    assert.deepStrictEqual(counts, { ifCreated: 1, ifDisposed: 0, elseCreated: 1, elseDisposed: 0 });
+
+    await fixture.stop(false);
+    await fixture.au.start();
+    assert.deepStrictEqual(counts, { ifCreated: 1, ifDisposed: 0, elseCreated: 1, elseDisposed: 0 });
+
+    await fixture.stop(true);
+    assert.deepStrictEqual(counts, { ifCreated: 1, ifDisposed: 1, elseCreated: 1, elseDisposed: 1 });
+  });
+
+  it('disposes dormant views when caching is disabled before selection or restart', async function () {
+    const counts = {
+      ifCreated: 0,
+      ifDisposed: 0,
+      elseCreated: 0,
+      elseDisposed: 0,
+    };
+    const IfBranch = CustomElement.define({ name: 'dormant-if-branch', template: 'if' }, class {
+      public constructor() { counts.ifCreated++; }
+      public dispose(): void { counts.ifDisposed++; }
+    });
+    const ElseBranch = CustomElement.define({ name: 'dormant-else-branch', template: 'else' }, class {
+      public constructor() { counts.elseCreated++; }
+      public dispose(): void { counts.elseDisposed++; }
+    });
+    const fixture = createFixture(
+      '<dormant-if-branch if="value.bind: show; cache.bind: cache"></dormant-if-branch>'
+      + '<dormant-else-branch else></dormant-else-branch>',
+      class App {
+        public show = true;
+        public cache = true;
+      },
+      [IfBranch, ElseBranch],
+    );
+    await fixture.started;
+
+    fixture.component.show = false;
+    await tasksSettled();
+    assert.deepStrictEqual(counts, { ifCreated: 1, ifDisposed: 0, elseCreated: 1, elseDisposed: 0 });
+
+    fixture.component.cache = false;
+    await tasksSettled();
+    fixture.component.show = true;
+    await tasksSettled();
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 1, elseCreated: 1, elseDisposed: 1 });
+
+    fixture.component.cache = true;
+    await tasksSettled();
+    fixture.component.show = false;
+    await tasksSettled();
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 1, elseCreated: 2, elseDisposed: 1 });
+
+    fixture.component.cache = false;
+    await tasksSettled();
+    await fixture.stop(false);
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 1, elseCreated: 2, elseDisposed: 1 });
+
+    await fixture.au.start();
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 3, elseDisposed: 2 });
+
+    await fixture.stop(true);
+    assert.deepStrictEqual(counts, { ifCreated: 2, ifDisposed: 2, elseCreated: 3, elseDisposed: 3 });
+  });
+
+  it('disposes nested uncached ownership when its outer view retires', async function () {
+    let created = 0;
+    let disposed = 0;
+    const Leaf = CustomElement.define({ name: 'nested-uncached-leaf', template: 'leaf' }, class {
+      public constructor() { created++; }
+      public dispose(): void { disposed++; }
+    });
+    const fixture = createFixture(
+      '<div if="value.bind: outer; cache: false">'
+      + '<nested-uncached-leaf if.bind="inner"></nested-uncached-leaf>'
+      + '</div>',
+      class App {
+        public outer = true;
+        public inner = true;
+      },
+      [Leaf],
+    );
+    await fixture.started;
+    assert.deepStrictEqual({ created, disposed }, { created: 1, disposed: 0 });
+
+    fixture.component.outer = false;
+    await tasksSettled();
+    assert.deepStrictEqual({ created, disposed }, { created: 1, disposed: 1 });
+
+    fixture.component.outer = true;
+    await tasksSettled();
+    assert.deepStrictEqual({ created, disposed }, { created: 2, disposed: 1 });
+
+    await fixture.stop(true);
+    assert.deepStrictEqual({ created, disposed }, { created: 2, disposed: 2 });
+  });
+
+  it('waits for rejected activation cleanup before disposing and entering uncached else', async function () {
+    const activation = new Deferred();
+    const cleanupStarted = new Deferred();
+    const cleanup = new Deferred();
+    const fallbackReattached = new Deferred();
+    let rejectingCreated = 0;
+    let rejectingDisposed = 0;
+    let fallbackCreated = 0;
+    let fallbackDisposed = 0;
+    let fallbackAttaches = 0;
+
+    const RejectingBranch = CustomElement.define({ name: 'uncached-rejecting-branch', template: 'rejecting' }, class {
+      public constructor() { rejectingCreated++; }
+      public attaching(): Promise<void> { return activation.promise; }
+      public detaching(): Promise<void> {
+        cleanupStarted.resolve();
+        return cleanup.promise;
+      }
+      public dispose(): void { rejectingDisposed++; }
+    });
+    const FallbackBranch = CustomElement.define({ name: 'uncached-fallback-branch', template: 'fallback' }, class {
+      public constructor() { fallbackCreated++; }
+      public attaching(): void {
+        if (++fallbackAttaches === 2) {
+          fallbackReattached.resolve();
+        }
+      }
+      public dispose(): void { fallbackDisposed++; }
+    });
+    const fixture = createFixture(
+      '<uncached-rejecting-branch if="value.bind: show; cache: false"></uncached-rejecting-branch>'
+      + '<uncached-fallback-branch else></uncached-fallback-branch>',
+      class App { public show = false; },
+      [RejectingBranch, FallbackBranch],
+    );
+    await fixture.started;
+    assert.deepStrictEqual(
+      { rejectingCreated, rejectingDisposed, fallbackCreated, fallbackDisposed },
+      { rejectingCreated: 0, rejectingDisposed: 0, fallbackCreated: 1, fallbackDisposed: 0 },
+    );
+
+    fixture.component.show = true;
+    assert.deepStrictEqual(
+      { rejectingCreated, rejectingDisposed, fallbackCreated, fallbackDisposed },
+      { rejectingCreated: 1, rejectingDisposed: 0, fallbackCreated: 1, fallbackDisposed: 1 },
+    );
+
+    activation.reject(new Error('expected activation rejection'));
+    await cleanupStarted.promise;
+    fixture.component.show = false;
+    await Promise.resolve();
+    assert.deepStrictEqual(
+      { rejectingCreated, rejectingDisposed, fallbackCreated, fallbackDisposed },
+      { rejectingCreated: 1, rejectingDisposed: 0, fallbackCreated: 1, fallbackDisposed: 1 },
+    );
+
+    cleanup.resolve();
+    await fallbackReattached.promise;
+    assert.deepStrictEqual(
+      { rejectingCreated, rejectingDisposed, fallbackCreated, fallbackDisposed },
+      { rejectingCreated: 1, rejectingDisposed: 1, fallbackCreated: 2, fallbackDisposed: 1 },
+    );
+
+    await fixture.stop(true);
+    assert.deepStrictEqual(
+      { rejectingCreated, rejectingDisposed, fallbackCreated, fallbackDisposed },
+      { rejectingCreated: 1, rejectingDisposed: 1, fallbackCreated: 2, fallbackDisposed: 2 },
+    );
+  });
+});

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -149,22 +149,14 @@ export class If implements ICustomAttributeViewModel {
     // ends If's ownership instead, so every owned slot is disposed directly.
     const ifView = this.ifView;
     const elseView = this.elseView;
-    const currentView = this.view;
-    const ownsView = view !== void 0
-      && (currentView === view || ifView === view || elseView === view);
-    this.ifView = this.elseView = void 0;
-    if (currentView === view || currentView === ifView || currentView === elseView) {
-      this.view = void 0;
+    view?.dispose();
+    if (ifView !== view) {
+      ifView?.dispose();
     }
-    if (ownsView) {
-      view.dispose();
+    if (elseView !== view) {
+      elseView?.dispose();
     }
-    if (ifView !== void 0 && ifView !== view) {
-      ifView.dispose();
-    }
-    if (elseView !== void 0 && elseView !== view && elseView !== ifView) {
-      elseView.dispose();
-    }
+    this.ifView = this.elseView = this.view = void 0;
   }
 
   /**

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -33,7 +33,7 @@ export class If implements ICustomAttributeViewModel {
 
   public value: unknown = false;
   /**
-   * `false` to always dispose the existing `view` whenever the value of if changes to false
+   * `false` to dispose branch views after deactivation instead of retaining them for reuse.
    */
   public cache: boolean = true;
   private pending: void | Promise<void> = void 0;
@@ -89,6 +89,7 @@ export class If implements ICustomAttributeViewModel {
       () => this.pending = onResolve(
         currView?.isActive ? currView.deactivate(currView, ctrl) : void 0,
         () => {
+          this._disposeViewsIfUncached(currView);
           if (!isCurrent()) {
             return;
           }
@@ -121,13 +122,17 @@ export class If implements ICustomAttributeViewModel {
           };
           const result = view.activate(view, ctrl, ctrl.scope);
           if (recoverAfterFailure && isPromise(result)) {
-            return result.then(complete, () => {
-              complete();
+            return result.then(complete, () => onResolve(
               // Value-driven swaps historically remain reusable after an async
               // branch failure. Initial activation uses the rejecting path so
-              // application start still reports an invalid initial tree.
-              void view!.deactivate(view!, ctrl);
-            });
+              // application start still reports an invalid initial tree. Keep
+              // teardown in this chain so a successor cannot overlap the failed view.
+              view!.deactivate(view!, ctrl),
+              () => {
+                this._disposeViewsIfUncached(view);
+                complete();
+              },
+            ));
           }
           return onResolve(result, complete);
         }
@@ -135,7 +140,37 @@ export class If implements ICustomAttributeViewModel {
     );
   }
 
-  /** @internal SSR hydration: adopt existing DOM instead of creating new views. */
+  /** @internal */
+  private _disposeViewsIfUncached(view: ISyntheticView | undefined): void {
+    if (this.cache) {
+      return;
+    }
+    // `release()` delegates retention to ViewFactory caching. `cache: false`
+    // ends If's ownership instead, so every owned slot is disposed directly.
+    const ifView = this.ifView;
+    const elseView = this.elseView;
+    const currentView = this.view;
+    const ownsView = view !== void 0
+      && (currentView === view || ifView === view || elseView === view);
+    this.ifView = this.elseView = void 0;
+    if (currentView === view || currentView === ifView || currentView === elseView) {
+      this.view = void 0;
+    }
+    if (ownsView) {
+      view.dispose();
+    }
+    if (ifView !== void 0 && ifView !== view) {
+      ifView.dispose();
+    }
+    if (elseView !== void 0 && elseView !== view && elseView !== ifView) {
+      elseView.dispose();
+    }
+  }
+
+  /**
+   * SSR hydration: adopt existing DOM instead of creating new views.
+   * @internal
+   */
   private _hydrateView(ssrScope: ISSRTemplateController): void | Promise<void> {
     const ctrl = this.$controller;
     const wasIfBranch = (ssrScope.state as { value?: boolean } | undefined)?.value === true;

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -845,10 +845,12 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     let prevActivation: void | Promise<void> = void 0;
     switch ((this.state & ~released)) {
       case activated:
-        this.state = deactivating;
+        // release() is consumed by unbind after teardown settles. Preserve the
+        // bit while moving through deactivating so the factory can recycle it.
+        this.state = (deactivating | (this.state & released)) as State;
         break;
       case activating:
-        this.state = deactivating;
+        this.state = (deactivating | (this.state & released)) as State;
         // we are about to deactivate, the error from activation can be ignored
         prevActivation = this.$promise?.catch(__DEV__
           /* istanbul-ignore-next */

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -1007,11 +1007,14 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   /** @internal */
   private _ensurePromise(): void {
     if (this.$promise === void 0) {
-      this.$promise = new Promise((resolve, reject) => {
+      const promise = this.$promise = new Promise((resolve, reject) => {
         this.$resolve = resolve;
         this.$reject = reject;
       });
       if (this.$initiator !== this) {
+        // Ancestor traversal owns the public failure boundary. Observe this
+        // descendant-local mirror so the same error is not also host-unhandled.
+        void promise.catch(noop);
         (this.parent as Controller)._ensurePromise();
       }
     }


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

Three lifecycle cleanup paths could leave view ownership incomplete:

- An ancestor-driven child lifecycle failure rejected both the initiator Promise and an unobserved descendant Controller Promise.
- `if` with `cache: false` created fresh branches but did not dispose views it stopped retaining.
- `release()` lost its state when a synthetic view entered deactivation, preventing the existing `ViewFactory` cache-or-dispose logic from running.

## 💁 Your Solution

- Observe descendant-local lifecycle Promises when an ancestor owns the public operation. The initiator still receives the original failure.
- Dispose uncached `if` and `else` views after successful deactivation, including dormant views retained before caching was disabled. Failed branch cleanup also finishes before a replacement can activate.
- Preserve the released state through deactivation until `unbind()` returns the view to its configured factory cache or disposes it.

The released-state change adds no allocations to synchronous lifecycle paths. Its measured bundle impact is 28 minified bytes.

### 🔗 Related Work

- Follows #2461, which established owner-local async lifecycle coordination and exposed these remaining cleanup gaps.
- Precedes #2453, which will build its `else if` lifecycle behavior on the corrected base `If`, Controller, and synthetic-view ownership semantics.

## 📑 Test Plan

- Added Node and Chrome coverage for lifecycle error identity and duplicate unhandled rejections.
- Added `if` lifecycle coverage for synchronous and asynchronous cleanup, rapid supersession, cache changes, restart, nesting, and activation failure.
- Added real Repeat/ViewFactory coverage for synchronous and asynchronous recycling, pending activation, disabled caching, and cache overflow.

## 📦 Changeset

- [x] Added a changeset