### PR TITLE
fix(vite-plugin): correctly resolve vite mode

### DIFF
--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -51,11 +51,20 @@ describe('vite-plugin', function () {
     } as unknown as import('vite').ResolvedConfig;
   }
 
-  function createConfig(mode: string) {
+  function createConfig(mode?: string) {
     return {
-      mode,
+      ...(mode === void 0 ? {} : { mode }),
       resolve: { alias: [], dedupe: [], conditions: [] },
     } as unknown as import('vite').UserConfig;
+  }
+
+  function createConfigEnv(mode: string, command: 'build' | 'serve' = 'build') {
+    return {
+      mode,
+      command,
+      isSsrBuild: false,
+      isPreview: false,
+    } as import('vite').ConfigEnv;
   }
 
   function createPluginContext() {
@@ -94,6 +103,14 @@ describe('vite-plugin', function () {
 
     assert.equal(thirdParty, null);
     assert.equal(subpath, null);
+  });
+
+  it('does not rewrite Aurelia package imports for production builds when config.mode is omitted', async function () {
+    const [devPlugin, resourcePlugin] = au();
+    getHook(devPlugin.config)?.call({}, createConfig(), createConfigEnv('production'));
+
+    const resolved = await getHook(resourcePlugin.resolveId)?.call(createPluginContext(), '@aurelia/kernel', '/src/app.ts', {});
+    assert.equal(resolved, null);
   });
 
   it('rewrites conventional html imports for literal production mode', async function () {

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -54,8 +54,9 @@ export default function au(options: AureliaPluginOptions = {}) {
 
   const devPlugin: import('vite').Plugin = {
     name: 'aurelia:dev-alias',
-    config(config) {
-      useDevImports = useDev === true || (useDev == null && config.mode !== 'production');
+    config(config, env) {
+      const mode = config.mode ?? env.mode;
+      useDevImports = useDev === true || (useDev == null && mode !== 'production');
     },
   };
 


### PR DESCRIPTION
## 📖 Description

As per reported in #2463, the vite plugin is effectively using `config.mode !== 'production'` to check whether it's a production build. This is not true for `vite build`. Vite build provides 2 params:
```ts
config(config: UserConfig, env: ConfigEnv) {
  // UserConfig.mode?: string
  // ConfigEnv.mode: string
}
```
so we should have
```ts
config(config, env) {
  const mode = config.mode ?? env.mode;
  useDevImports = useDev === true || (useDev == null && mode !== 'production');
}
```
instead of
```ts
config(config: UserConfig, env: ConfigEnv) {
  // if config.mode is undefined, and useDev is not specified, we have useDevImports as true
  useDevImports = useDev === true || (useDev == null && config.mode !== 'production');
}
```

### 🎫 Issues

Closes #2463

Thanks @dkent600