### PR TITLE
feat(vite-plugin): add ability to bundle asset via relative url

### DIFF
--- a/.changeset/vite-template-assets.md
+++ b/.changeset/vite-template-assets.md
@@ -1,0 +1,6 @@
+---
+"@aurelia/plugin-conventions": patch
+"@aurelia/vite-plugin": patch
+---
+
+Bundle static relative asset URLs referenced from conventional HTML templates during Vite production builds.

--- a/docs/user-docs/developer-guides/bundlers/README.md
+++ b/docs/user-docs/developer-guides/bundlers/README.md
@@ -339,6 +339,21 @@ export class MyComponent {
 }
 ```
 
+With `@aurelia/vite-plugin`, static relative asset URLs in conventional HTML templates are also included in production builds:
+
+```html
+<template>
+  <img src="logo.svg" alt="Logo">
+  <img src="./logo.svg" alt="Logo">
+  <img src="../shared/shared-logo.svg" alt="Shared logo">
+  <img srcset="./logo.png 1x, ./logo@2x.png 2x" alt="Logo">
+</template>
+```
+
+Relative URLs are resolved from the HTML template file, so same-directory paths, `./`, `../`, and nested relative paths are supported.
+
+Use binding for dynamic URLs. Root-relative public paths, external URLs, data URLs, hashes, and missing files are left unchanged.
+
 ## Performance Optimization
 
 ### Bundle Splitting

--- a/docs/user-docs/developer-guides/bundlers/README.md
+++ b/docs/user-docs/developer-guides/bundlers/README.md
@@ -351,8 +351,13 @@ With `@aurelia/vite-plugin`, static relative asset URLs in conventional HTML tem
 ```
 
 Relative URLs are resolved from the HTML template file, so same-directory paths, `./`, `../`, and nested relative paths are supported.
+The supported elements and attributes match Vite's standard HTML asset sources.
 
-Use binding for dynamic URLs. Root-relative public paths, external URLs, data URLs, hashes, and missing files are left unchanged.
+Use binding for dynamic URLs. Root-relative public paths, external URLs, data URLs, and hashes are left unchanged. Missing relative assets are left unchanged with a build warning.
+
+Only assets backed by files on disk are transformed for now. Virtual assets provided exclusively by Vite plugins are left unchanged and reported as unresolved.
+
+Set `transformTemplateAssets: false` in the Aurelia Vite plugin options to opt out and leave all template asset URLs unchanged.
 
 ## Performance Optimization
 

--- a/docs/user-docs/developer-guides/bundlers/README.md
+++ b/docs/user-docs/developer-guides/bundlers/README.md
@@ -352,8 +352,11 @@ With `@aurelia/vite-plugin`, static relative asset URLs in conventional HTML tem
 
 Relative URLs are resolved from the HTML template file, so same-directory paths, `./`, `../`, and nested relative paths are supported.
 The supported elements and attributes match Vite's standard HTML asset sources.
+Final asset URLs follow Vite's configured base path, output directory, file naming, hashing, and plugin transformations.
 
 Use binding for dynamic URLs. Root-relative public paths, external URLs, data URLs, and hashes are left unchanged. Missing relative assets are left unchanged with a build warning.
+
+Add `au-vite-ignore` to an element to leave its asset URLs unchanged. The marker attribute is removed from the compiled template.
 
 Only assets backed by files on disk are transformed for now. Virtual assets provided exclusively by Vite plugins are left unchanged and reported as unresolved.
 

--- a/docs/user-docs/developer-guides/bundlers/README.md
+++ b/docs/user-docs/developer-guides/bundlers/README.md
@@ -339,7 +339,7 @@ export class MyComponent {
 }
 ```
 
-With `@aurelia/vite-plugin`, static relative asset URLs in conventional HTML templates are also included in production builds:
+With `@aurelia/vite-plugin`, static relative asset URLs in conventional HTML templates are also processed through the vite asset pipeline:
 
 ```html
 <template>
@@ -354,13 +354,13 @@ Relative URLs are resolved from the HTML template file, so same-directory paths,
 The supported elements and attributes match Vite's standard HTML asset sources.
 Final asset URLs follow Vite's configured base path, output directory, file naming, hashing, and plugin transformations.
 
-Use binding for dynamic URLs. Root-relative public paths, external URLs, data URLs, and hashes are left unchanged. Missing relative assets are left unchanged with a build warning.
+Use binding for dynamic URLs. Root-relative public paths, external URLs, data URLs, and hashes are left unchanged. Missing relative assets are left unchanged with a build warning by default.
 
-Add `au-vite-ignore` to an element to leave its asset URLs unchanged. The marker attribute is removed from the compiled template.
+Add `au-vite-ignore` to an element to leave its asset URLs unchanged and bypass missing-asset warnings or errors. The marker attribute is removed from the compiled template.
 
-Only assets backed by files on disk are transformed for now. Virtual assets provided exclusively by Vite plugins are left unchanged and reported as unresolved.
+Only assets backed by files on disk are transformed for now. Virtual assets provided exclusively by Vite plugins are handled as unresolved relative assets.
 
-Set `transformTemplateAssets: false` in the Aurelia Vite plugin options to opt out and leave all template asset URLs unchanged.
+Set `transformTemplateAssets: 'error'` to stop the Vite transform when a relative asset cannot be resolved. `true` and `'warn'` use the default warning behavior; set the option to `false` to opt out and leave all template asset URLs unchanged.
 
 ## Performance Optimization
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27080,7 +27080,8 @@
         "@swc/helpers": "0.5.23",
         "@swc/wasm": "1.15.47",
         "get-tsconfig": "4.14.0",
-        "loader-utils": "^2.0.0"
+        "loader-utils": "^2.0.0",
+        "parse5": "^7.1.2"
       },
       "devDependencies": {
         "@types/loader-utils": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "packages/__e2e__/14-vite8-decorators",
         "packages/__e2e__/15-ts6-webpack-smoke",
         "packages/__e2e__/16-ts7-webpack-smoke",
+        "packages/__e2e__/17-vite-template-assets",
         "benchmarks",
         "examples/1kcomponents",
         "examples/doc-example",
@@ -588,6 +589,10 @@
     },
     "node_modules/@__e2e__/16-ts7-webpack-smoke": {
       "resolved": "packages/__e2e__/16-ts7-webpack-smoke",
+      "link": true
+    },
+    "node_modules/@__e2e__/17-vite-template-assets": {
+      "resolved": "packages/__e2e__/17-vite-template-assets",
       "link": true
     },
     "node_modules/@__e2e__/2-hmr-vite": {
@@ -28117,6 +28122,24 @@
       },
       "bin": {
         "tsc6": "bin/tsc6"
+      }
+    },
+    "packages/__e2e__/17-vite-template-assets": {
+      "name": "@__e2e__/17-vite-template-assets",
+      "version": "2.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "aurelia": "2.0.0-rc.2"
+      },
+      "devDependencies": {
+        "@aurelia/vite-plugin": "2.0.0-rc.2",
+        "@playwright/test": "1.62.1",
+        "@types/node": "22.20.1",
+        "playwright": "1.62.1",
+        "vite": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=22.22.2"
       }
     },
     "packages/__e2e__/2-hmr-vite": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "packages/__e2e__/14-vite8-decorators",
     "packages/__e2e__/15-ts6-webpack-smoke",
     "packages/__e2e__/16-ts7-webpack-smoke",
+    "packages/__e2e__/17-vite-template-assets",
     "benchmarks",
     "examples/1kcomponents",
     "examples/doc-example",

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
@@ -1243,5 +1243,39 @@ export function register(container) {
       );
       assert.equal(result.code, expected);
     });
+
+    it('preprocesses templates with transformHtmlTemplate option', function () {
+      const html = [
+        '<template><img src="./logo.png"></template>'
+      ].join('');
+      const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import assetUrl from "./logo.png";
+export const name = "foo-bar";
+export const template = "<template><img src=\\"" + assetUrl + "\\"></template>";
+export default template;
+export const dependencies = [  ];
+export const bindables = {};
+let _e;
+export function register(container) {
+  if (!_e) {
+    _e = CustomElement.define({ name, template, dependencies, bindables });
+  }
+  container.register(_e);
+}
+`;
+      const result = preprocessHtmlTemplate(
+        { path: path.join('lo', 'foo-bar', 'index.html'), contents: html },
+        preprocessOptions({
+          hmr: false,
+          transformHtmlTemplate: () => ({
+            imports: ['import assetUrl from "./logo.png";\n'],
+            template: '"<template><img src=\\"" + assetUrl + "\\"></template>"',
+          }),
+        }),
+        false,
+        () => false
+      );
+      assert.equal(result.code, expected);
+    });
   });
 });

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
@@ -1244,10 +1244,11 @@ export function register(container) {
       assert.equal(result.code, expected);
     });
 
-    it('preprocesses templates with transformHtmlTemplate option', function () {
+    it('preprocesses templates with a structured transformHtml result', function () {
       const html = [
         '<template><img src="./logo.png"></template>'
       ].join('');
+      const unit = { path: path.join('lo', 'foo-bar', 'index.html'), contents: html };
       const expected = `import { CustomElement } from '@aurelia/runtime-html';
 import assetUrl from "./logo.png";
 export const name = "foo-bar";
@@ -1264,13 +1265,16 @@ export function register(container) {
 }
 `;
       const result = preprocessHtmlTemplate(
-        { path: path.join('lo', 'foo-bar', 'index.html'), contents: html },
+        unit,
         preprocessOptions({
           hmr: false,
-          transformHtmlTemplate: () => ({
-            imports: ['import assetUrl from "./logo.png";\n'],
-            template: '"<template><img src=\\"" + assetUrl + "\\"></template>"',
-          }),
+          transformHtml: (_html, receivedUnit) => {
+            assert.equal(receivedUnit, unit);
+            return {
+              imports: ['import assetUrl from "./logo.png";\n'],
+              template: '"<template><img src=\\"" + assetUrl + "\\"></template>"',
+            };
+          },
         }),
         false,
         () => false

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
@@ -1272,7 +1272,7 @@ export function register(container) {
             assert.equal(receivedUnit, unit);
             return {
               imports: ['import assetUrl from "./logo.png";\n'],
-              template: '"<template><img src=\\"" + assetUrl + "\\"></template>"',
+              templateExpression: '"<template><img src=\\"" + assetUrl + "\\"></template>"',
             };
           },
         }),

--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -69,8 +69,13 @@ describe('vite-plugin', function () {
   }
 
   function createPluginContext() {
+    const warnings: string[] = [];
     return {
+      warnings,
       meta: { watchMode: false },
+      warn(message: string) {
+        warnings.push(message);
+      },
       async resolve(id: string) {
         return { id: `/resolved/${id}` };
       },
@@ -172,6 +177,7 @@ describe('vite-plugin', function () {
         '<img src.bind="dynamicLogo">',
         '<img src="/public-logo.png">',
         '<img src="./missing.png">',
+        '<img src="./missing.png?size=2">',
         '</template>',
       ].join('\n'),
       'utf8'
@@ -179,7 +185,8 @@ describe('vite-plugin', function () {
 
     try {
       getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
-      const result = await getHook(resourcePlugin.load)?.call(createPluginContext(), fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const context = createPluginContext();
+      const result = await getHook(resourcePlugin.load)?.call(context, fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
       const code = typeof result === 'string' ? result : result?.code;
 
       assert.match(String(code), /import __auViteAsset0 from "\.\/logo\.png";/);
@@ -190,6 +197,10 @@ describe('vite-plugin', function () {
       assert.match(String(code), /src\.bind=\\"dynamicLogo\\"/);
       assert.match(String(code), /src=\\"\/public-logo\.png\\"/);
       assert.match(String(code), /src=\\"\.\/missing\.png\\"/);
+      assert.match(String(code), /src=\\"\.\/missing\.png\?size=2\\"/);
+      assert.deepEqual(context.warnings, [
+        `Unable to resolve template asset "./missing.png" referenced by ${JSON.stringify(fixture.htmlFile)}. The URL will be left unchanged.`,
+      ]);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }
@@ -221,7 +232,7 @@ describe('vite-plugin', function () {
     }
   });
 
-  it('imports Vue-style static template asset attributes during production builds', async function () {
+  it('imports Vite asset source attributes during production builds', async function () {
     const fixture = createFixture();
     const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
 
@@ -233,6 +244,16 @@ describe('vite-plugin', function () {
       'source-2x.webm',
       'image.svg',
       'symbol.svg',
+      'audio.mp3',
+      'embed.svg',
+      'input.png',
+      'link.png',
+      'link-2x.png',
+      'object.pdf',
+      'track.vtt',
+      'meta-name.png',
+      'meta-property.png',
+      'non-asset-meta.png',
     ].forEach(file => fs.writeFileSync(path.join(fixture.srcDir, file), file, 'utf8'));
     fs.writeFileSync(
       fixture.htmlFile,
@@ -245,6 +266,15 @@ describe('vite-plugin', function () {
         '  <image href="./image.svg" xlink:href="./image.svg"></image>',
         '  <use href="./symbol.svg" xlink:href="./symbol.svg"></use>',
         '</svg>',
+        '<audio src="./audio.mp3"></audio>',
+        '<embed src="./embed.svg">',
+        '<input type="image" src="./input.png">',
+        '<link rel="icon" href="./link.png" imagesrcset="./link.png 1x, ./link-2x.png 2x">',
+        '<object data="./object.pdf"></object>',
+        '<track src="./track.vtt">',
+        '<meta name="twitter:image" content="./meta-name.png">',
+        '<meta property="og:image" content="./meta-property.png">',
+        '<meta name="description" content="./non-asset-meta.png">',
         '</template>',
       ].join('\n'),
       'utf8'
@@ -261,7 +291,17 @@ describe('vite-plugin', function () {
       assert.match(String(code), /import __auViteAsset3 from "\.\/source-2x\.webm";/);
       assert.match(String(code), /import __auViteAsset4 from "\.\/image\.svg";/);
       assert.match(String(code), /import __auViteAsset5 from "\.\/symbol\.svg";/);
-      assert.match(String(code), /export const template = .*__auViteAsset0.*__auViteAsset1.*__auViteAsset2.*__auViteAsset2.*__auViteAsset3.*__auViteAsset4.*__auViteAsset4.*__auViteAsset5.*__auViteAsset5/s);
+      assert.match(String(code), /import __auViteAsset6 from "\.\/audio\.mp3";/);
+      assert.match(String(code), /import __auViteAsset7 from "\.\/embed\.svg";/);
+      assert.match(String(code), /import __auViteAsset8 from "\.\/input\.png";/);
+      assert.match(String(code), /import __auViteAsset9 from "\.\/link\.png";/);
+      assert.match(String(code), /import __auViteAsset10 from "\.\/link-2x\.png";/);
+      assert.match(String(code), /import __auViteAsset11 from "\.\/object\.pdf";/);
+      assert.match(String(code), /import __auViteAsset12 from "\.\/track\.vtt";/);
+      assert.match(String(code), /import __auViteAsset13 from "\.\/meta-name\.png";/);
+      assert.match(String(code), /import __auViteAsset14 from "\.\/meta-property\.png";/);
+      assert.doesNotMatch(String(code), /import .*non-asset-meta/);
+      assert.match(String(code), /content=\\"\.\/non-asset-meta\.png\\"/);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }
@@ -368,6 +408,31 @@ await build({
 
       assert.doesNotMatch(String(code), /__auViteAsset/);
       assert.match(String(code), /export const template = "<img src=\\"\.\/logo\.png\\" alt=\\"Logo\\">";/);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('can disable static template asset transforms', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({
+      include: /\.(ts|js|html)$/,
+      transformTemplateAssets: false,
+    });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(path.join(fixture.srcDir, 'logo.png'), 'logo', 'utf8');
+    fs.writeFileSync(fixture.htmlFile, '<img src="./logo.png"><img src="./missing.png">', 'utf8');
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const context = createPluginContext();
+      const result = await getHook(resourcePlugin.load)?.call(context, fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const code = typeof result === 'string' ? result : result?.code;
+
+      assert.doesNotMatch(String(code), /__auViteAsset/);
+      assert.match(String(code), /export const template = "<img src=\\"\.\/logo\.png\\"><img src=\\"\.\/missing\.png\\">";/);
+      assert.deepEqual(context.warnings, []);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }

--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import au from '@aurelia/vite-plugin';
@@ -144,6 +145,203 @@ describe('vite-plugin', function () {
       const code = typeof result === 'string' ? result : result?.code;
 
       assert.match(String(code), /import \* as __au2ViewDef from '\.\/foo-bar\.\$au\.ts';/);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('imports static relative template assets during production builds', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.mkdirSync(path.join(fixture.srcDir, 'nested'), { recursive: true });
+    fs.mkdirSync(path.join(fixture.root, 'shared'), { recursive: true });
+    fs.writeFileSync(path.join(fixture.srcDir, 'logo.png'), 'logo', 'utf8');
+    fs.writeFileSync(path.join(fixture.srcDir, 'larger.png'), 'larger', 'utf8');
+    fs.writeFileSync(path.join(fixture.srcDir, 'nested', 'nested-logo.png'), 'nested-logo', 'utf8');
+    fs.writeFileSync(path.join(fixture.root, 'shared', 'shared-logo.png'), 'shared-logo', 'utf8');
+    fs.writeFileSync(
+      fixture.htmlFile,
+      [
+        '<template>',
+        '<img src="./logo.png" alt="Logo">',
+        '<img src="../shared/shared-logo.png" alt="Shared logo">',
+        '<img src="nested/nested-logo.png" alt="Nested logo">',
+        '<img srcset="./logo.png 1x, ./larger.png 2x">',
+        '<img src.bind="dynamicLogo">',
+        '<img src="/public-logo.png">',
+        '<img src="./missing.png">',
+        '</template>',
+      ].join('\n'),
+      'utf8'
+    );
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const result = await getHook(resourcePlugin.load)?.call(createPluginContext(), fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const code = typeof result === 'string' ? result : result?.code;
+
+      assert.match(String(code), /import __auViteAsset0 from "\.\/logo\.png";/);
+      assert.match(String(code), /import __auViteAsset1 from "\.\.\/shared\/shared-logo\.png";/);
+      assert.match(String(code), /import __auViteAsset2 from "\.\/nested\/nested-logo\.png";/);
+      assert.match(String(code), /import __auViteAsset3 from "\.\/larger\.png";/);
+      assert.match(String(code), /export const template = .*__auViteAsset0.*__auViteAsset1.*__auViteAsset2.*__auViteAsset0.*__auViteAsset3/s);
+      assert.match(String(code), /src\.bind=\\"dynamicLogo\\"/);
+      assert.match(String(code), /src=\\"\/public-logo\.png\\"/);
+      assert.match(String(code), /src=\\"\.\/missing\.png\\"/);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('imports Vue-style static template asset attributes during production builds', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    [
+      'clip.mp4',
+      'poster.png',
+      'source.webm',
+      'source-2x.webm',
+      'image.svg',
+      'symbol.svg',
+    ].forEach(file => fs.writeFileSync(path.join(fixture.srcDir, file), file, 'utf8'));
+    fs.writeFileSync(
+      fixture.htmlFile,
+      [
+        '<template>',
+        '<video src="./clip.mp4" poster="./poster.png">',
+        '  <source src="./source.webm" srcset="./source.webm 1x, ./source-2x.webm 2x">',
+        '</video>',
+        '<svg>',
+        '  <image href="./image.svg" xlink:href="./image.svg"></image>',
+        '  <use href="./symbol.svg" xlink:href="./symbol.svg"></use>',
+        '</svg>',
+        '</template>',
+      ].join('\n'),
+      'utf8'
+    );
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const result = await getHook(resourcePlugin.load)?.call(createPluginContext(), fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const code = typeof result === 'string' ? result : result?.code;
+
+      assert.match(String(code), /import __auViteAsset0 from "\.\/clip\.mp4";/);
+      assert.match(String(code), /import __auViteAsset1 from "\.\/poster\.png";/);
+      assert.match(String(code), /import __auViteAsset2 from "\.\/source\.webm";/);
+      assert.match(String(code), /import __auViteAsset3 from "\.\/source-2x\.webm";/);
+      assert.match(String(code), /import __auViteAsset4 from "\.\/image\.svg";/);
+      assert.match(String(code), /import __auViteAsset5 from "\.\/symbol\.svg";/);
+      assert.match(String(code), /export const template = .*__auViteAsset0.*__auViteAsset1.*__auViteAsset2.*__auViteAsset2.*__auViteAsset3.*__auViteAsset4.*__auViteAsset4.*__auViteAsset5.*__auViteAsset5/s);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('emits static relative template assets in Vite production builds', async function () {
+    const fixture = createFixture();
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fixture.root, 'index.html'),
+      '<div id="app"></div><script type="module" src="/src/main.ts"></script>',
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(fixture.srcDir, 'main.ts'),
+      [
+        'import * as view from "./foo-bar.html";',
+        'console.log(view.template);',
+      ].join('\n'),
+      'utf8'
+    );
+    fs.writeFileSync(fixture.htmlFile, '<template><img id="logo" src="./logo.svg" alt="Logo"></template>', 'utf8');
+    fs.writeFileSync(path.join(fixture.srcDir, 'logo.svg'), '<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'utf8');
+
+    try {
+      execFileSync(process.execPath, [
+        '--input-type=module',
+        '--eval',
+        `import { build } from 'vite';
+import au from '@aurelia/vite-plugin';
+await build({
+  root: process.argv[1],
+  configFile: false,
+  logLevel: 'silent',
+  build: {
+    assetsInlineLimit: 0,
+    minify: false,
+  },
+  plugins: au(),
+});`,
+        fixture.root,
+      ], { cwd: process.cwd(), stdio: 'pipe' });
+
+      const distAssets = fs.readdirSync(path.join(fixture.root, 'dist', 'assets'));
+      assert.ok(distAssets.some(file => /^logo-.*\.svg$/.test(file)));
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves non-bundleable template asset URLs unchanged during production builds', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(path.join(fixture.srcDir, 'ignored.png'), 'ignored', 'utf8');
+    fs.writeFileSync(
+      fixture.htmlFile,
+      [
+        '<template>',
+        '<img vite-ignore src="./ignored.png">',
+        '<img src="/public-logo.png">',
+        '<img src="https://example.com/logo.png">',
+        '<img src="//example.com/logo.png">',
+        '<img src="data:image/png;base64,AA==">',
+        '<img src="#symbol">',
+        '<img src="$' + '{logoUrl}">',
+        '</template>',
+      ].join('\n'),
+      'utf8'
+    );
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const result = await getHook(resourcePlugin.load)?.call(createPluginContext(), fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const code = String(typeof result === 'string' ? result : result?.code);
+
+      assert.doesNotMatch(code, /__auViteAsset/);
+      assert.match(code, /src=\\"\.\/ignored\.png\\"/);
+      assert.match(code, /src=\\"\/public-logo\.png\\"/);
+      assert.match(code, /src=\\"https:\/\/example\.com\/logo\.png\\"/);
+      assert.match(code, /src=\\"\/\/example\.com\/logo\.png\\"/);
+      assert.match(code, /src=\\"data:image\/png;base64,AA==\\"/);
+      assert.match(code, /src=\\"#symbol\\"/);
+      assert.ok(code.includes('src=\\"$' + '{logoUrl}\\"'));
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not import static relative template assets during dev server transforms', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(path.join(fixture.srcDir, 'logo.png'), 'logo', 'utf8');
+    fs.writeFileSync(fixture.htmlFile, '<img src="./logo.png" alt="Logo">', 'utf8');
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('development', 'serve'));
+      const result = await getHook(resourcePlugin.transform)?.call({}, '<img src="./logo.png" alt="Logo">', fixture.htmlFile);
+      const code = typeof result === 'string' ? result : result?.code;
+
+      assert.doesNotMatch(String(code), /__auViteAsset/);
+      assert.match(String(code), /export const template = "<img src=\\"\.\/logo\.png\\" alt=\\"Logo\\">";/);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }

--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -195,6 +195,32 @@ describe('vite-plugin', function () {
     }
   });
 
+  it('processes assets after a string transformHtml result', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({
+      include: /\.(ts|js|html)$/,
+      transformHtml: (html, unit) => {
+        assert.equal(unit.path, fixture.htmlFile);
+        return html.replace('</template>', '<img src="./logo.png"></template>');
+      },
+    });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(path.join(fixture.srcDir, 'logo.png'), 'logo', 'utf8');
+    fs.writeFileSync(fixture.htmlFile, '<template></template>', 'utf8');
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const result = await getHook(resourcePlugin.load)?.call(createPluginContext(), fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const code = typeof result === 'string' ? result : result?.code;
+
+      assert.match(String(code), /import __auViteAsset0 from "\.\/logo\.png";/);
+      assert.match(String(code), /export const template = .*__auViteAsset0/s);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
   it('imports Vue-style static template asset attributes during production builds', async function () {
     const fixture = createFixture();
     const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });

--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -363,7 +363,7 @@ await build({
       fixture.htmlFile,
       [
         '<template>',
-        '<img vite-ignore src="./ignored.png">',
+        '<img au-vite-ignore src="./ignored.png">',
         '<img src="/public-logo.png">',
         '<img src="https://example.com/logo.png">',
         '<img src="//example.com/logo.png">',
@@ -381,6 +381,7 @@ await build({
       const code = String(typeof result === 'string' ? result : result?.code);
 
       assert.doesNotMatch(code, /__auViteAsset/);
+      assert.doesNotMatch(code, /au-vite-ignore/);
       assert.match(code, /src=\\"\.\/ignored\.png\\"/);
       assert.match(code, /src=\\"\/public-logo\.png\\"/);
       assert.match(code, /src=\\"https:\/\/example\.com\/logo\.png\\"/);

--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -76,6 +76,9 @@ describe('vite-plugin', function () {
       warn(message: string) {
         warnings.push(message);
       },
+      error(message: string): never {
+        throw new Error(message);
+      },
       async resolve(id: string) {
         return { id: `/resolved/${id}` };
       },
@@ -394,7 +397,7 @@ await build({
     }
   });
 
-  it('does not import static relative template assets during dev server transforms', async function () {
+  it('imports static relative template assets during dev server transforms', async function () {
     const fixture = createFixture();
     const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
 
@@ -407,8 +410,8 @@ await build({
       const result = await getHook(resourcePlugin.transform)?.call({}, '<img src="./logo.png" alt="Logo">', fixture.htmlFile);
       const code = typeof result === 'string' ? result : result?.code;
 
-      assert.doesNotMatch(String(code), /__auViteAsset/);
-      assert.match(String(code), /export const template = "<img src=\\"\.\/logo\.png\\" alt=\\"Logo\\">";/);
+      assert.match(String(code), /import __auViteAsset0 from "\.\/logo\.png";/);
+      assert.match(String(code), /export const template = .*__auViteAsset0/s);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }
@@ -433,6 +436,34 @@ await build({
 
       assert.doesNotMatch(String(code), /__auViteAsset/);
       assert.match(String(code), /export const template = "<img src=\\"\.\/logo\.png\\"><img src=\\"\.\/missing\.png\\">";/);
+      assert.deepEqual(context.warnings, []);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('can fail production builds for missing relative template assets', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({
+      include: /\.(ts|js|html)$/,
+      transformTemplateAssets: 'error',
+    });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(fixture.htmlFile, '<img src="./missing.png">', 'utf8');
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const context = createPluginContext();
+
+      await assert.rejects(
+        getHook(resourcePlugin.load)?.call(context, fixture.htmlFile.replace(/\.html$/, '.$au.ts')),
+        (error: unknown) => {
+          assert.ok(error instanceof Error);
+          assert.equal(error.message, `Unable to resolve template asset "./missing.png" referenced by ${JSON.stringify(fixture.htmlFile)}.`);
+          return true;
+        },
+      );
       assert.deepEqual(context.warnings, []);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });

--- a/packages-tooling/plugin-conventions/src/index.ts
+++ b/packages-tooling/plugin-conventions/src/index.ts
@@ -8,7 +8,7 @@ export {
   type INameConvention,
   type IFileUnit,
   type IFileUnitHost,
-  type IHtmlTemplateTransformResult,
+  type IHtmlTransformResult,
   type IOptionalPreprocessOptions,
   type IPreprocessOptions,
   defaultCssExtensions,

--- a/packages-tooling/plugin-conventions/src/index.ts
+++ b/packages-tooling/plugin-conventions/src/index.ts
@@ -8,6 +8,7 @@ export {
   type INameConvention,
   type IFileUnit,
   type IFileUnitHost,
+  type IHtmlTemplateTransformResult,
   type IOptionalPreprocessOptions,
   type IPreprocessOptions,
   defaultCssExtensions,

--- a/packages-tooling/plugin-conventions/src/options.ts
+++ b/packages-tooling/plugin-conventions/src/options.ts
@@ -23,7 +23,7 @@ export interface IFileUnitHost {
   readFile(unit: IFileUnit, path: string): string;
 }
 
-export interface IHtmlTemplateTransformResult {
+export interface IHtmlTransformResult {
   imports?: readonly string[];
   template: string;
 }
@@ -61,12 +61,10 @@ export interface IOptionalPreprocessOptions {
   transformHtmlImportSpecifier?: (specifier: string) => string;
   /**
    * Used to transform the HTML content of a template file during preprocessing.
+   * Return a string to replace the HTML, or a result containing imports and a
+   * JavaScript expression for the generated template module.
    */
-  transformHtml?: (html: string) => string;
-  /**
-   * Used to transform the final HTML content into a JavaScript template expression.
-   */
-  transformHtmlTemplate?: (html: string, unit: IFileUnit) => IHtmlTemplateTransformResult | undefined;
+  transformHtml?: (html: string, unit: IFileUnit) => string | IHtmlTransformResult | undefined;
   /**
    * This gets the generated HMR code for the specified class
    *
@@ -107,12 +105,10 @@ export interface IPreprocessOptions {
   transformHtmlImportSpecifier?: (specifier: string) => string;
   /**
    * Used to transform the HTML content of a template file during preprocessing.
+   * Return a string to replace the HTML, or a result containing imports and a
+   * JavaScript expression for the generated template module.
    */
-  transformHtml?: (html: string) => string;
-  /**
-   * Used to transform the final HTML content into a JavaScript template expression.
-   */
-  transformHtmlTemplate?: (html: string, unit: IFileUnit) => IHtmlTemplateTransformResult | undefined;
+  transformHtml?: (html: string, unit: IFileUnit) => string | IHtmlTransformResult | undefined;
   /**
    * This gets the generated HMR code for the specified class
    *

--- a/packages-tooling/plugin-conventions/src/options.ts
+++ b/packages-tooling/plugin-conventions/src/options.ts
@@ -25,7 +25,7 @@ export interface IFileUnitHost {
 
 export interface IHtmlTransformResult {
   imports?: readonly string[];
-  template: string;
+  templateExpression: string;
 }
 
 export interface IOptionalPreprocessOptions {

--- a/packages-tooling/plugin-conventions/src/options.ts
+++ b/packages-tooling/plugin-conventions/src/options.ts
@@ -23,6 +23,11 @@ export interface IFileUnitHost {
   readFile(unit: IFileUnit, path: string): string;
 }
 
+export interface IHtmlTemplateTransformResult {
+  imports?: readonly string[];
+  template: string;
+}
+
 export interface IOptionalPreprocessOptions {
   defaultShadowOptions?: { mode: 'open' | 'closed' };
   // More details in ./preprocess-html-template.ts
@@ -58,6 +63,10 @@ export interface IOptionalPreprocessOptions {
    * Used to transform the HTML content of a template file during preprocessing.
    */
   transformHtml?: (html: string) => string;
+  /**
+   * Used to transform the final HTML content into a JavaScript template expression.
+   */
+  transformHtmlTemplate?: (html: string, unit: IFileUnit) => IHtmlTemplateTransformResult | undefined;
   /**
    * This gets the generated HMR code for the specified class
    *
@@ -100,6 +109,10 @@ export interface IPreprocessOptions {
    * Used to transform the HTML content of a template file during preprocessing.
    */
   transformHtml?: (html: string) => string;
+  /**
+   * Used to transform the final HTML content into a JavaScript template expression.
+   */
+  transformHtmlTemplate?: (html: string, unit: IFileUnit) => IHtmlTemplateTransformResult | undefined;
   /**
    * This gets the generated HMR code for the specified class
    *

--- a/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
@@ -136,11 +136,15 @@ export function preprocessHtmlTemplate(
     viewDeps.push(`cssModules(${cssModuleDeps.join(', ')})`);
   }
   statements.forEach(st => m.append(st));
-  const transformedHtml = options.transformHtml?.(html) ?? html;
-  const transformedTemplate = options.transformHtmlTemplate?.(transformedHtml, unit);
-  transformedTemplate?.imports?.forEach(st => m.append(st));
+  const htmlTransformResult = options.transformHtml?.(html, unit) ?? html;
+  const template = typeof htmlTransformResult === 'string'
+    ? s(htmlTransformResult)
+    : htmlTransformResult.template;
+  if (typeof htmlTransformResult !== 'string') {
+    htmlTransformResult.imports?.forEach(st => m.append(st));
+  }
   m.append(`export const name = ${s(name)};
-export const template = ${transformedTemplate?.template ?? s(transformedHtml)};
+export const template = ${template};
 export default template;
 export const dependencies = [ ${viewDeps.join(', ')} ];
 `);

--- a/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
@@ -139,7 +139,7 @@ export function preprocessHtmlTemplate(
   const htmlTransformResult = options.transformHtml?.(html, unit) ?? html;
   const template = typeof htmlTransformResult === 'string'
     ? s(htmlTransformResult)
-    : htmlTransformResult.template;
+    : htmlTransformResult.templateExpression;
   if (typeof htmlTransformResult !== 'string') {
     htmlTransformResult.imports?.forEach(st => m.append(st));
   }

--- a/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
@@ -136,8 +136,11 @@ export function preprocessHtmlTemplate(
     viewDeps.push(`cssModules(${cssModuleDeps.join(', ')})`);
   }
   statements.forEach(st => m.append(st));
+  const transformedHtml = options.transformHtml?.(html) ?? html;
+  const transformedTemplate = options.transformHtmlTemplate?.(transformedHtml, unit);
+  transformedTemplate?.imports?.forEach(st => m.append(st));
   m.append(`export const name = ${s(name)};
-export const template = ${s(options.transformHtml?.(html) ?? html)};
+export const template = ${transformedTemplate?.template ?? s(transformedHtml)};
 export default template;
 export const dependencies = [ ${viewDeps.join(', ')} ];
 `);

--- a/packages-tooling/vite-plugin/README.md
+++ b/packages-tooling/vite-plugin/README.md
@@ -89,6 +89,7 @@ During production builds, the plugin processes static relative asset URLs in con
 ```
 
 Relative URLs are resolved from the HTML template file, so same-directory paths, `./`, `../`, and nested relative paths are supported.
+The supported elements and attributes match Vite's standard HTML asset sources, including images and source sets, audio, video, embedded content, links, and asset metadata.
 
 Use binding for dynamic URLs as usual:
 
@@ -96,7 +97,17 @@ Use binding for dynamic URLs as usual:
 <img src.bind="logoUrl" alt="Logo">
 ```
 
-Root-relative public paths such as `/logo.svg`, external URLs, data URLs, hashes, and missing files are left unchanged.
+Root-relative public paths such as `/logo.svg`, external URLs, data URLs, and hashes are left unchanged. Missing relative assets are also left unchanged and produce a build warning.
+
+Only assets backed by files on disk are transformed for now. Virtual assets provided exclusively by Vite plugins are not supported; their URLs are left unchanged and reported as unresolved.
+
+Set `transformTemplateAssets` to `false` to leave every template asset URL unchanged:
+
+```ts
+export default defineConfig({
+  plugins: [aurelia({ transformTemplateAssets: false })],
+});
+```
 
 ### Development builds
 

--- a/packages-tooling/vite-plugin/README.md
+++ b/packages-tooling/vite-plugin/README.md
@@ -77,7 +77,7 @@ declare module '*.html' {
 
 ### Template assets
 
-During production builds, the plugin processes static relative asset URLs in conventional HTML templates so Vite can emit and rewrite them:
+During development and production builds, the plugin processes static relative asset URLs in conventional HTML templates so Vite can serve, emit, and rewrite them:
 
 ```html
 <template>
@@ -104,17 +104,27 @@ Use binding for dynamic URLs as usual:
 <img src.bind="logoUrl" alt="Logo">
 ```
 
-Root-relative public paths such as `/logo.svg`, external URLs, data URLs, and hashes are left unchanged. Missing relative assets are also left unchanged and produce a build warning.
+Root-relative public paths such as `/logo.svg`, external URLs, data URLs, and hashes are left unchanged. Missing relative assets produce a build warning by default and are left unchanged.
 
-Only assets backed by files on disk are transformed for now. Virtual assets provided exclusively by Vite plugins are not supported; their URLs are left unchanged and reported as unresolved.
+Only assets backed by files on disk are transformed for now. Virtual assets provided exclusively by Vite plugins are not supported and are handled as unresolved relative assets.
 
-Set `transformTemplateAssets` to `false` to leave every template asset URL unchanged:
+Use `transformTemplateAssets` to control processing and missing relative assets:
+
+| Value | Behavior |
+|---|---|
+| `true` or `'warn'` | Transform assets; warn and preserve URLs that cannot be resolved. This is the default. |
+| `'error'` | Transform assets; stop the Vite transform when a relative asset cannot be resolved. |
+| `false` | Disable template asset processing and leave every URL unchanged. |
+
+For example, to require every relative template asset to resolve:
 
 ```ts
 export default defineConfig({
-  plugins: [aurelia({ transformTemplateAssets: false })],
+  plugins: [aurelia({ transformTemplateAssets: 'error' })],
 });
 ```
+
+Elements marked with `au-vite-ignore` bypass both missing-asset warnings and errors.
 
 ### Development builds
 

--- a/packages-tooling/vite-plugin/README.md
+++ b/packages-tooling/vite-plugin/README.md
@@ -75,6 +75,29 @@ declare module '*.html' {
 }
 ```
 
+### Template assets
+
+During production builds, the plugin processes static relative asset URLs in conventional HTML templates so Vite can emit and rewrite them:
+
+```html
+<template>
+  <img src="logo.svg" alt="Logo">
+  <img src="./logo.svg" alt="Logo">
+  <img src="../shared/shared-logo.svg" alt="Shared logo">
+  <img srcset="./logo.png 1x, ./logo@2x.png 2x" alt="Logo">
+</template>
+```
+
+Relative URLs are resolved from the HTML template file, so same-directory paths, `./`, `../`, and nested relative paths are supported.
+
+Use binding for dynamic URLs as usual:
+
+```html
+<img src.bind="logoUrl" alt="Logo">
+```
+
+Root-relative public paths such as `/logo.svg`, external URLs, data URLs, hashes, and missing files are left unchanged.
+
 ### Development builds
 
 By default, the Aurelia Vite plugin aliases Aurelia packages to their development builds when Vite runs in development mode. Set `useDev` explicitly when you need to override Vite's automatic mode detection:

--- a/packages-tooling/vite-plugin/README.md
+++ b/packages-tooling/vite-plugin/README.md
@@ -90,6 +90,13 @@ During production builds, the plugin processes static relative asset URLs in con
 
 Relative URLs are resolved from the HTML template file, so same-directory paths, `./`, `../`, and nested relative paths are supported.
 The supported elements and attributes match Vite's standard HTML asset sources, including images and source sets, audio, video, embedded content, links, and asset metadata.
+The plugin hands each transformed URL to Vite, so the final URL follows Vite's `base`, `assetsDir`, asset file naming, hashing, and other plugin transformations.
+
+Add `au-vite-ignore` to an element to leave its asset URLs unchanged. The marker is removed from the compiled template:
+
+```html
+<img au-vite-ignore src="./logo.svg" alt="Logo">
+```
 
 Use binding for dynamic URLs as usual:
 

--- a/packages-tooling/vite-plugin/package.json
+++ b/packages-tooling/vite-plugin/package.json
@@ -54,7 +54,8 @@
     "@swc/helpers": "0.5.23",
     "@swc/wasm": "1.15.47",
     "get-tsconfig": "4.14.0",
-    "loader-utils": "^2.0.0"
+    "loader-utils": "^2.0.0",
+    "parse5": "^7.1.2"
   },
   "peerDependencies": {
     "vite": "^7.0.2 || ^8.0.0"

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -7,6 +7,8 @@ import { promises } from 'fs';
 import { createStandardDecoratorPlugin, normalizeFilterId } from './standard-decorators';
 import { transformTemplateAssetUrls } from './template-assets';
 
+export type TemplateAssetMode = 'warn' | 'error';
+
 export interface AureliaPluginOptions extends IOptionalPreprocessOptions {
   include?: FilterPattern;
   exclude?: FilterPattern;
@@ -16,11 +18,13 @@ export interface AureliaPluginOptions extends IOptionalPreprocessOptions {
    */
   useDev?: boolean;
   /**
-   * Transform static asset URLs in HTML templates during production builds.
+   * Transform static asset URLs in HTML templates and
+   * control how missing relative assets are handled.
    *
-   * Defaults to true.
+   * `true` is equivalent to `'warn'`; `false` disables the transform.
+   * Defaults to `'warn'`.
    */
-  transformTemplateAssets?: boolean;
+  transformTemplateAssets?: boolean | TemplateAssetMode;
   /**
    * Transform TC39 standard decorators before Vite compiles application modules.
    *
@@ -50,7 +54,7 @@ export default function au(options: AureliaPluginOptions = {}) {
     exclude,
     pre = true,
     useDev,
-    transformTemplateAssets = true,
+    transformTemplateAssets = 'warn',
     transformStandardDecorators,
     standardDecoratorInclude,
     standardDecoratorExclude,
@@ -71,12 +75,25 @@ export default function au(options: AureliaPluginOptions = {}) {
   };
 
   let $config!: import('vite').ResolvedConfig;
-  const transformHtmlForVite = (html: string, unit: IFileUnit, warn: (message: string) => void) => {
+  const transformHtmlForVite = (
+    html: string,
+    unit: IFileUnit,
+    context: {
+      warn(message: string): void;
+      error(message: string): never;
+    },
+  ) => {
     const transformedHtml = transformHtml?.(html, unit) ?? html;
-    if (!transformTemplateAssets || typeof transformedHtml !== 'string' || $config.command !== 'build') {
+    if (transformTemplateAssets === false || typeof transformedHtml !== 'string') {
       return transformedHtml;
     }
-    return transformTemplateAssetUrls(transformedHtml, unit, nodeFileUnitHost, warn) ?? transformedHtml;
+    return transformTemplateAssetUrls(transformedHtml, unit, nodeFileUnitHost, (specifier) => {
+      const message = `Unable to resolve template asset ${JSON.stringify(specifier)} referenced by ${JSON.stringify(unit.path)}.`;
+      if (transformTemplateAssets === 'error') {
+        context.error(message);
+      }
+      context.warn(`${message} The URL will be left unchanged.`);
+    }) ?? transformedHtml;
   };
 
   const auPlugin: import('vite').Plugin = {
@@ -103,7 +120,7 @@ export default function au(options: AureliaPluginOptions = {}) {
             ? s.replace(/\.html$/, '.$au.ts')
             : s;
         },
-        transformHtml: (html, unit) => transformHtmlForVite(html, unit, warning => this.warn(warning)),
+        transformHtml: (html, unit) => transformHtmlForVite(html, unit, this),
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions,
         isDev: $config.command !== 'build',
@@ -146,7 +163,7 @@ export default function au(options: AureliaPluginOptions = {}) {
       }, {
         hmrModule: 'import.meta',
         transformHtmlImportSpecifier: s => s.replace(/\.html$/, '.$au.ts'),
-        transformHtml: (html, unit) => transformHtmlForVite(html, unit, warning => this.warn(warning)),
+        transformHtml: (html, unit) => transformHtmlForVite(html, unit, this),
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions,
         isDev: $config.command !== 'build',

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -16,6 +16,12 @@ export interface AureliaPluginOptions extends IOptionalPreprocessOptions {
    */
   useDev?: boolean;
   /**
+   * Transform static asset URLs in HTML templates during production builds.
+   *
+   * Defaults to true.
+   */
+  transformTemplateAssets?: boolean;
+  /**
    * Transform TC39 standard decorators before Vite compiles application modules.
    *
    * Defaults to true on Vite 8 and false on Vite 7. Set this to false when a
@@ -44,6 +50,7 @@ export default function au(options: AureliaPluginOptions = {}) {
     exclude,
     pre = true,
     useDev,
+    transformTemplateAssets = true,
     transformStandardDecorators,
     standardDecoratorInclude,
     standardDecoratorExclude,
@@ -64,12 +71,12 @@ export default function au(options: AureliaPluginOptions = {}) {
   };
 
   let $config!: import('vite').ResolvedConfig;
-  const transformHtmlForVite = (html: string, unit: IFileUnit) => {
+  const transformHtmlForVite = (html: string, unit: IFileUnit, warn: (message: string) => void) => {
     const transformedHtml = transformHtml?.(html, unit) ?? html;
-    if (typeof transformedHtml !== 'string' || $config.command !== 'build') {
+    if (!transformTemplateAssets || typeof transformedHtml !== 'string' || $config.command !== 'build') {
       return transformedHtml;
     }
-    return transformTemplateAssetUrls(transformedHtml, unit.path) ?? transformedHtml;
+    return transformTemplateAssetUrls(transformedHtml, unit.path, warn) ?? transformedHtml;
   };
 
   const auPlugin: import('vite').Plugin = {
@@ -96,7 +103,7 @@ export default function au(options: AureliaPluginOptions = {}) {
             ? s.replace(/\.html$/, '.$au.ts')
             : s;
         },
-        transformHtml: transformHtmlForVite,
+        transformHtml: (html, unit) => transformHtmlForVite(html, unit, warning => this.warn(warning)),
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions,
         isDev: $config.command !== 'build',
@@ -139,7 +146,7 @@ export default function au(options: AureliaPluginOptions = {}) {
       }, {
         hmrModule: 'import.meta',
         transformHtmlImportSpecifier: s => s.replace(/\.html$/, '.$au.ts'),
-        transformHtml: transformHtmlForVite,
+        transformHtml: (html, unit) => transformHtmlForVite(html, unit, warning => this.warn(warning)),
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions,
         isDev: $config.command !== 'build',

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -1,9 +1,11 @@
-import { IOptionalPreprocessOptions, preprocess } from '@aurelia/plugin-conventions';
+import { preprocess } from '@aurelia/plugin-conventions';
+import type { IFileUnit, IOptionalPreprocessOptions } from '@aurelia/plugin-conventions';
 import { nodeFileUnitHost } from '@aurelia/plugin-conventions/node';
 import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import { resolve, dirname } from 'path';
 import { promises } from 'fs';
 import { createStandardDecoratorPlugin, normalizeFilterId } from './standard-decorators';
+import { transformTemplateAssetUrls } from './template-assets';
 
 export interface AureliaPluginOptions extends IOptionalPreprocessOptions {
   include?: FilterPattern;
@@ -45,6 +47,7 @@ export default function au(options: AureliaPluginOptions = {}) {
     transformStandardDecorators,
     standardDecoratorInclude,
     standardDecoratorExclude,
+    transformHtmlTemplate,
     ...additionalOptions
   } = options;
   const filter = createFilter(include, exclude);
@@ -61,6 +64,10 @@ export default function au(options: AureliaPluginOptions = {}) {
   };
 
   let $config!: import('vite').ResolvedConfig;
+  const transformHtmlTemplateForVite = (html: string, unit: IFileUnit) => {
+    return transformHtmlTemplate?.(html, unit)
+      ?? ($config.command === 'build' ? transformTemplateAssetUrls(html, unit.path) : void 0);
+  };
 
   const auPlugin: import('vite').Plugin = {
     name: 'au2',
@@ -86,6 +93,7 @@ export default function au(options: AureliaPluginOptions = {}) {
             ? s.replace(/\.html$/, '.$au.ts')
             : s;
         },
+        transformHtmlTemplate: transformHtmlTemplateForVite,
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions,
         isDev: $config.command !== 'build',
@@ -128,6 +136,7 @@ export default function au(options: AureliaPluginOptions = {}) {
       }, {
         hmrModule: 'import.meta',
         transformHtmlImportSpecifier: s => s.replace(/\.html$/, '.$au.ts'),
+        transformHtmlTemplate: transformHtmlTemplateForVite,
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions,
         isDev: $config.command !== 'build',

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -76,7 +76,7 @@ export default function au(options: AureliaPluginOptions = {}) {
     if (!transformTemplateAssets || typeof transformedHtml !== 'string' || $config.command !== 'build') {
       return transformedHtml;
     }
-    return transformTemplateAssetUrls(transformedHtml, unit.path, warn) ?? transformedHtml;
+    return transformTemplateAssetUrls(transformedHtml, unit, nodeFileUnitHost, warn) ?? transformedHtml;
   };
 
   const auPlugin: import('vite').Plugin = {

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -47,7 +47,7 @@ export default function au(options: AureliaPluginOptions = {}) {
     transformStandardDecorators,
     standardDecoratorInclude,
     standardDecoratorExclude,
-    transformHtmlTemplate,
+    transformHtml,
     ...additionalOptions
   } = options;
   const filter = createFilter(include, exclude);
@@ -64,9 +64,12 @@ export default function au(options: AureliaPluginOptions = {}) {
   };
 
   let $config!: import('vite').ResolvedConfig;
-  const transformHtmlTemplateForVite = (html: string, unit: IFileUnit) => {
-    return transformHtmlTemplate?.(html, unit)
-      ?? ($config.command === 'build' ? transformTemplateAssetUrls(html, unit.path) : void 0);
+  const transformHtmlForVite = (html: string, unit: IFileUnit) => {
+    const transformedHtml = transformHtml?.(html, unit) ?? html;
+    if (typeof transformedHtml !== 'string' || $config.command !== 'build') {
+      return transformedHtml;
+    }
+    return transformTemplateAssetUrls(transformedHtml, unit.path) ?? transformedHtml;
   };
 
   const auPlugin: import('vite').Plugin = {
@@ -93,7 +96,7 @@ export default function au(options: AureliaPluginOptions = {}) {
             ? s.replace(/\.html$/, '.$au.ts')
             : s;
         },
-        transformHtmlTemplate: transformHtmlTemplateForVite,
+        transformHtml: transformHtmlForVite,
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions,
         isDev: $config.command !== 'build',
@@ -136,7 +139,7 @@ export default function au(options: AureliaPluginOptions = {}) {
       }, {
         hmrModule: 'import.meta',
         transformHtmlImportSpecifier: s => s.replace(/\.html$/, '.$au.ts'),
-        transformHtmlTemplate: transformHtmlTemplateForVite,
+        transformHtml: transformHtmlForVite,
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions,
         isDev: $config.command !== 'build',

--- a/packages-tooling/vite-plugin/src/template-assets.ts
+++ b/packages-tooling/vite-plugin/src/template-assets.ts
@@ -1,0 +1,213 @@
+import { statSync } from 'fs';
+import type { IHtmlTemplateTransformResult } from '@aurelia/plugin-conventions';
+import { dirname, resolve } from 'path';
+import { parseFragment } from 'parse5';
+import type { DefaultTreeAdapterMap, Token } from 'parse5';
+
+type DefaultTreeNode = DefaultTreeAdapterMap['node'];
+type DefaultTreeElement = DefaultTreeAdapterMap['element'];
+type DefaultTreeTemplate = DefaultTreeAdapterMap['template'];
+type AttributeLocation = Token.Location;
+
+const htmlAssetAttributes: Record<string, { src?: readonly string[]; srcset?: readonly string[] }> = {
+  img: { src: ['src'], srcset: ['srcset'] },
+  image: { src: ['href', 'xlink:href'] },
+  source: { src: ['src'], srcset: ['srcset'] },
+  use: { src: ['href', 'xlink:href'] },
+  video: { src: ['src', 'poster'] },
+};
+
+interface Replacement {
+  start: number;
+  end: number;
+  value: string;
+}
+
+interface AssetToken {
+  token: string;
+  variable: string;
+  specifier: string;
+}
+
+export function transformTemplateAssetUrls(html: string, htmlId: string): IHtmlTemplateTransformResult | undefined {
+  const replacements: Replacement[] = [];
+  const assets: AssetToken[] = [];
+  const tree = parseFragment(html, { sourceCodeLocationInfo: true });
+
+  visitElements(tree.childNodes, (node) => {
+    const assetAttrs = htmlAssetAttributes[node.nodeName];
+    const attrs = getAttributes(node);
+    if (assetAttrs == null || attrs.has('vite-ignore')) return;
+
+    assetAttrs.src?.forEach((name) => {
+      const value = attrs.get(name);
+      const loc = node.sourceCodeLocation?.attrs?.[name];
+      if (value == null || loc == null) return;
+
+      const token = createAssetToken(value, htmlId, assets);
+      if (token == null) return;
+      const valueLocation = getAttributeValueLocation(html, loc);
+      if (valueLocation == null) return;
+      replacements.push({ ...valueLocation, value: token.token });
+    });
+
+    assetAttrs.srcset?.forEach((name) => {
+      const value = attrs.get(name);
+      const loc = node.sourceCodeLocation?.attrs?.[name];
+      if (value == null || loc == null) return;
+      replaceSrcset(value, loc, html, htmlId, replacements, assets);
+    });
+  });
+
+  if (assets.length === 0) return void 0;
+
+  const transformedHtml = applyReplacements(html, replacements);
+  const imports = assets.map(asset => `import ${asset.variable} from ${JSON.stringify(asset.specifier)};\n`);
+  return {
+    imports,
+    template: createTemplateExpression(transformedHtml, assets),
+  };
+}
+
+function visitElements(nodes: DefaultTreeNode[], callback: (node: DefaultTreeElement) => void): void {
+  for (const node of nodes) {
+    if (!('attrs' in node)) continue;
+
+    const element = node as DefaultTreeElement;
+    callback(element);
+
+    visitElements(element.childNodes, callback);
+    if (element.tagName === 'template') {
+      visitElements((element as DefaultTreeTemplate).content.childNodes, callback);
+    }
+  }
+}
+
+function getAttributes(node: DefaultTreeElement): Map<string, string> {
+  const attrs = new Map<string, string>();
+  for (const attr of node.attrs) {
+    attrs.set(attr.prefix == null ? attr.name : `${attr.prefix}:${attr.name}`, attr.value);
+  }
+  return attrs;
+}
+
+function replaceSrcset(
+  value: string,
+  attrLocation: AttributeLocation,
+  html: string,
+  htmlId: string,
+  replacements: Replacement[],
+  assets: AssetToken[],
+): void {
+  const valueLocation = getAttributeValueLocation(html, attrLocation);
+  if (valueLocation == null) return;
+
+  let changed = false;
+  const srcset = value.replace(/(^|,)(\s*)([^,\s]+)([^,]*)/g, (match, separator: string, whitespace: string, url: string, descriptor: string) => {
+    const token = createAssetToken(url, htmlId, assets);
+    if (token == null) return match;
+    changed = true;
+    return `${separator}${whitespace}${token.token}${descriptor}`;
+  });
+
+  if (changed) {
+    replacements.push({ ...valueLocation, value: srcset });
+  }
+}
+
+function createAssetToken(specifier: string, htmlId: string, assets: AssetToken[]): AssetToken | undefined {
+  if (!shouldBundleAsset(specifier, htmlId)) return void 0;
+  const importSpecifier = specifier.startsWith('.') ? specifier : `./${specifier}`;
+  const existingAsset = assets.find(asset => asset.specifier === importSpecifier);
+  if (existingAsset != null) return existingAsset;
+
+  const token = `__au_vite_asset_${assets.length}__`;
+  const asset = {
+    token,
+    variable: `__auViteAsset${assets.length}`,
+    specifier: importSpecifier,
+  };
+  assets.push(asset);
+  return asset;
+}
+
+function shouldBundleAsset(specifier: string, htmlId: string): boolean {
+  if (
+    specifier === ''
+    || specifier.includes('${')
+    || specifier.startsWith('/')
+    || specifier.startsWith('#')
+    || /^[a-z][a-z\d+.-]*:/i.test(specifier)
+    || specifier.startsWith('//')
+  ) {
+    return false;
+  }
+
+  const filePath = getFilePath(specifier);
+  if (filePath == null) return false;
+
+  const resolved = resolve(dirname(htmlId), filePath);
+  try {
+    return statSync(resolved).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function getFilePath(specifier: string): string | undefined {
+  const [filePath] = specifier.split(/[?#]/, 1);
+  if (filePath === '') return void 0;
+  try {
+    return decodeURI(filePath);
+  } catch {
+    return void 0;
+  }
+}
+
+function getAttributeValueLocation(html: string, attrLocation: AttributeLocation): { start: number; end: number } | undefined {
+  const raw = html.slice(attrLocation.startOffset, attrLocation.endOffset);
+  const equals = raw.indexOf('=');
+  if (equals < 0) return void 0;
+
+  let start = attrLocation.startOffset + equals + 1;
+  while (/\s/.test(html[start])) {
+    start++;
+  }
+
+  const quote = html[start];
+  if (quote === '"' || quote === "'") {
+    return { start: start + 1, end: attrLocation.endOffset - 1 };
+  }
+
+  return { start, end: attrLocation.endOffset };
+}
+
+function applyReplacements(html: string, replacements: Replacement[]): string {
+  return replacements
+    .sort((a, b) => b.start - a.start)
+    .reduce((output, replacement) => {
+      return `${output.slice(0, replacement.start)}${replacement.value}${output.slice(replacement.end)}`;
+    }, html);
+}
+
+function createTemplateExpression(html: string, assets: AssetToken[]): string {
+  const tokenToVariable = new Map(assets.map(asset => [asset.token, asset.variable]));
+  const tokenPattern = new RegExp(assets.map(asset => asset.token).join('|'), 'g');
+  const parts: string[] = [];
+  let offset = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenPattern.exec(html)) !== null) {
+    if (match.index > offset) {
+      parts.push(JSON.stringify(html.slice(offset, match.index)));
+    }
+    parts.push(tokenToVariable.get(match[0])!);
+    offset = match.index + match[0].length;
+  }
+
+  if (offset < html.length) {
+    parts.push(JSON.stringify(html.slice(offset)));
+  }
+
+  return parts.join(' + ');
+}

--- a/packages-tooling/vite-plugin/src/template-assets.ts
+++ b/packages-tooling/vite-plugin/src/template-assets.ts
@@ -63,7 +63,7 @@ export function transformTemplateAssetUrls(
   html: string,
   unit: IFileUnit,
   host: IFileUnitHost,
-  warn: (message: string) => void,
+  reportMissingAsset: (specifier: string) => void,
 ): IHtmlTransformResult | undefined {
   const replacements: Replacement[] = [];
   const assets: AssetToken[] = [];
@@ -89,7 +89,7 @@ export function transformTemplateAssetUrls(
       const loc = node.sourceCodeLocation?.attrs?.[name];
       if (value == null || loc == null) return;
 
-      const token = createAssetToken(value, unit, host, assets, fileExistsCache, warn);
+      const token = createAssetToken(value, unit, host, assets, fileExistsCache, reportMissingAsset);
       if (token == null) return;
       const valueLocation = getAttributeValueLocation(html, loc);
       if (valueLocation == null) return;
@@ -100,7 +100,7 @@ export function transformTemplateAssetUrls(
       const value = attrs.get(name);
       const loc = node.sourceCodeLocation?.attrs?.[name];
       if (value == null || loc == null) return;
-      replaceSrcset(value, loc, html, unit, host, replacements, assets, fileExistsCache, warn);
+      replaceSrcset(value, loc, html, unit, host, replacements, assets, fileExistsCache, reportMissingAsset);
     });
   });
 
@@ -153,14 +153,14 @@ function replaceSrcset(
   replacements: Replacement[],
   assets: AssetToken[],
   fileExistsCache: Map<string, boolean>,
-  warn: (message: string) => void,
+  reportMissingAsset: (specifier: string) => void,
 ): void {
   const valueLocation = getAttributeValueLocation(html, attrLocation);
   if (valueLocation == null) return;
 
   let changed = false;
   const srcset = value.replace(/(^|,)(\s*)([^,\s]+)([^,]*)/g, (match, separator: string, whitespace: string, url: string, descriptor: string) => {
-    const token = createAssetToken(url, unit, host, assets, fileExistsCache, warn);
+    const token = createAssetToken(url, unit, host, assets, fileExistsCache, reportMissingAsset);
     if (token == null) return match;
     changed = true;
     return `${separator}${whitespace}${token.token}${descriptor}`;
@@ -177,12 +177,12 @@ function createAssetToken(
   host: IFileUnitHost,
   assets: AssetToken[],
   fileExistsCache: Map<string, boolean>,
-  warn: (message: string) => void,
+  reportMissingAsset: (specifier: string) => void,
 ): AssetToken | undefined {
   const importSpecifier = specifier.startsWith('.') ? specifier : `./${specifier}`;
   const existingAsset = assets.find(asset => asset.specifier === importSpecifier);
   if (existingAsset != null) return existingAsset;
-  if (!shouldBundleAsset(specifier, unit, host, fileExistsCache, warn)) return void 0;
+  if (!shouldBundleAsset(specifier, unit, host, fileExistsCache, reportMissingAsset)) return void 0;
 
   const token = `__au_vite_asset_${assets.length}__`;
   const asset = {
@@ -199,7 +199,7 @@ function shouldBundleAsset(
   unit: IFileUnit,
   host: IFileUnitHost,
   fileExistsCache: Map<string, boolean>,
-  warn: (message: string) => void,
+  reportMissingAsset: (specifier: string) => void,
 ): boolean {
   if (
     specifier === ''
@@ -222,7 +222,7 @@ function shouldBundleAsset(
   const exists = host.fileExists(unit, relativePath);
   fileExistsCache.set(relativePath, exists);
   if (!exists) {
-    warn(`Unable to resolve template asset ${JSON.stringify(specifier)} referenced by ${JSON.stringify(unit.path)}. The URL will be left unchanged.`);
+    reportMissingAsset(specifier);
   }
   return exists;
 }

--- a/packages-tooling/vite-plugin/src/template-assets.ts
+++ b/packages-tooling/vite-plugin/src/template-assets.ts
@@ -9,10 +9,41 @@ type DefaultTreeElement = DefaultTreeAdapterMap['element'];
 type DefaultTreeTemplate = DefaultTreeAdapterMap['template'];
 type AttributeLocation = Token.Location;
 
-const htmlAssetAttributes: Record<string, { src?: readonly string[]; srcset?: readonly string[] }> = {
+interface HtmlAssetAttributes {
+  src?: readonly string[];
+  srcset?: readonly string[];
+  filter?: (attributes: ReadonlyMap<string, string>) => boolean;
+}
+
+const allowedMetaNames = new Set([
+  'msapplication-tileimage',
+  'msapplication-square70x70logo',
+  'msapplication-square150x150logo',
+  'msapplication-wide310x150logo',
+  'msapplication-square310x310logo',
+  'msapplication-config',
+  'twitter:image',
+]);
+const allowedMetaProperties = new Set([
+  'og:image',
+  'og:image:url',
+  'og:image:secure_url',
+  'og:audio',
+  'og:audio:secure_url',
+  'og:video',
+  'og:video:secure_url',
+]);
+const htmlAssetAttributes: Record<string, HtmlAssetAttributes> = {
+  audio: { src: ['src'] },
+  embed: { src: ['src'] },
   img: { src: ['src'], srcset: ['srcset'] },
   image: { src: ['href', 'xlink:href'] },
+  input: { src: ['src'] },
+  link: { src: ['href'], srcset: ['imagesrcset'] },
+  meta: { src: ['content'], filter: isAssetMeta },
+  object: { src: ['data'] },
   source: { src: ['src'], srcset: ['srcset'] },
+  track: { src: ['src'] },
   use: { src: ['href', 'xlink:href'] },
   video: { src: ['src', 'poster'] },
 };
@@ -29,22 +60,29 @@ interface AssetToken {
   specifier: string;
 }
 
-export function transformTemplateAssetUrls(html: string, htmlId: string): IHtmlTransformResult | undefined {
+export function transformTemplateAssetUrls(
+  html: string,
+  htmlId: string,
+  warn: (message: string) => void,
+): IHtmlTransformResult | undefined {
   const replacements: Replacement[] = [];
   const assets: AssetToken[] = [];
+  const fileExistsCache = new Map<string, boolean>();
   const tree = parseFragment(html, { sourceCodeLocationInfo: true });
 
   visitElements(tree.childNodes, (node) => {
     const assetAttrs = htmlAssetAttributes[node.nodeName];
+    if (assetAttrs == null) return;
+
     const attrs = getAttributes(node);
-    if (assetAttrs == null || attrs.has('vite-ignore')) return;
+    if (attrs.has('vite-ignore') || assetAttrs.filter?.(attrs) === false) return;
 
     assetAttrs.src?.forEach((name) => {
       const value = attrs.get(name);
       const loc = node.sourceCodeLocation?.attrs?.[name];
       if (value == null || loc == null) return;
 
-      const token = createAssetToken(value, htmlId, assets);
+      const token = createAssetToken(value, htmlId, assets, fileExistsCache, warn);
       if (token == null) return;
       const valueLocation = getAttributeValueLocation(html, loc);
       if (valueLocation == null) return;
@@ -55,7 +93,7 @@ export function transformTemplateAssetUrls(html: string, htmlId: string): IHtmlT
       const value = attrs.get(name);
       const loc = node.sourceCodeLocation?.attrs?.[name];
       if (value == null || loc == null) return;
-      replaceSrcset(value, loc, html, htmlId, replacements, assets);
+      replaceSrcset(value, loc, html, htmlId, replacements, assets, fileExistsCache, warn);
     });
   });
 
@@ -65,7 +103,7 @@ export function transformTemplateAssetUrls(html: string, htmlId: string): IHtmlT
   const imports = assets.map(asset => `import ${asset.variable} from ${JSON.stringify(asset.specifier)};\n`);
   return {
     imports,
-    template: createTemplateExpression(transformedHtml, assets),
+    templateExpression: createTemplateExpression(transformedHtml, assets),
   };
 }
 
@@ -91,6 +129,14 @@ function getAttributes(node: DefaultTreeElement): Map<string, string> {
   return attrs;
 }
 
+function isAssetMeta(attributes: ReadonlyMap<string, string>): boolean {
+  const name = attributes.get('name')?.trim().toLowerCase();
+  if (name != null && allowedMetaNames.has(name)) return true;
+
+  const property = attributes.get('property')?.trim().toLowerCase();
+  return property != null && allowedMetaProperties.has(property);
+}
+
 function replaceSrcset(
   value: string,
   attrLocation: AttributeLocation,
@@ -98,13 +144,15 @@ function replaceSrcset(
   htmlId: string,
   replacements: Replacement[],
   assets: AssetToken[],
+  fileExistsCache: Map<string, boolean>,
+  warn: (message: string) => void,
 ): void {
   const valueLocation = getAttributeValueLocation(html, attrLocation);
   if (valueLocation == null) return;
 
   let changed = false;
   const srcset = value.replace(/(^|,)(\s*)([^,\s]+)([^,]*)/g, (match, separator: string, whitespace: string, url: string, descriptor: string) => {
-    const token = createAssetToken(url, htmlId, assets);
+    const token = createAssetToken(url, htmlId, assets, fileExistsCache, warn);
     if (token == null) return match;
     changed = true;
     return `${separator}${whitespace}${token.token}${descriptor}`;
@@ -115,11 +163,17 @@ function replaceSrcset(
   }
 }
 
-function createAssetToken(specifier: string, htmlId: string, assets: AssetToken[]): AssetToken | undefined {
-  if (!shouldBundleAsset(specifier, htmlId)) return void 0;
+function createAssetToken(
+  specifier: string,
+  htmlId: string,
+  assets: AssetToken[],
+  fileExistsCache: Map<string, boolean>,
+  warn: (message: string) => void,
+): AssetToken | undefined {
   const importSpecifier = specifier.startsWith('.') ? specifier : `./${specifier}`;
   const existingAsset = assets.find(asset => asset.specifier === importSpecifier);
   if (existingAsset != null) return existingAsset;
+  if (!shouldBundleAsset(specifier, htmlId, fileExistsCache, warn)) return void 0;
 
   const token = `__au_vite_asset_${assets.length}__`;
   const asset = {
@@ -131,7 +185,12 @@ function createAssetToken(specifier: string, htmlId: string, assets: AssetToken[
   return asset;
 }
 
-function shouldBundleAsset(specifier: string, htmlId: string): boolean {
+function shouldBundleAsset(
+  specifier: string,
+  htmlId: string,
+  fileExistsCache: Map<string, boolean>,
+  warn: (message: string) => void,
+): boolean {
   if (
     specifier === ''
     || specifier.includes('${')
@@ -147,11 +206,20 @@ function shouldBundleAsset(specifier: string, htmlId: string): boolean {
   if (filePath == null) return false;
 
   const resolved = resolve(dirname(htmlId), filePath);
+  const cached = fileExistsCache.get(resolved);
+  if (cached != null) return cached;
+
+  let exists = false;
   try {
-    return statSync(resolved).isFile();
+    exists = statSync(resolved).isFile();
   } catch {
-    return false;
+    // The unresolved URL remains in the template for backwards compatibility.
   }
+  fileExistsCache.set(resolved, exists);
+  if (!exists) {
+    warn(`Unable to resolve template asset ${JSON.stringify(specifier)} referenced by ${JSON.stringify(htmlId)}. The URL will be left unchanged.`);
+  }
+  return exists;
 }
 
 function getFilePath(specifier: string): string | undefined {

--- a/packages-tooling/vite-plugin/src/template-assets.ts
+++ b/packages-tooling/vite-plugin/src/template-assets.ts
@@ -33,6 +33,7 @@ const allowedMetaProperties = new Set([
   'og:video',
   'og:video:secure_url',
 ]);
+const ignoreAttribute = 'au-vite-ignore';
 const htmlAssetAttributes: Record<string, HtmlAssetAttributes> = {
   audio: { src: ['src'] },
   embed: { src: ['src'] },
@@ -71,11 +72,18 @@ export function transformTemplateAssetUrls(
   const tree = parseFragment(html, { sourceCodeLocationInfo: true });
 
   visitElements(tree.childNodes, (node) => {
+    const attrs = getAttributes(node);
+    if (attrs.has(ignoreAttribute)) {
+      const loc = node.sourceCodeLocation?.attrs?.[ignoreAttribute];
+      if (loc != null) {
+        replacements.push({ start: loc.startOffset, end: loc.endOffset, value: '' });
+      }
+      return;
+    }
+
     const assetAttrs = htmlAssetAttributes[node.nodeName];
     if (assetAttrs == null) return;
-
-    const attrs = getAttributes(node);
-    if (attrs.has('vite-ignore') || assetAttrs.filter?.(attrs) === false) return;
+    if (assetAttrs.filter?.(attrs) === false) return;
 
     assetAttrs.src?.forEach((name) => {
       const value = attrs.get(name);
@@ -97,13 +105,13 @@ export function transformTemplateAssetUrls(
     });
   });
 
-  if (assets.length === 0) return void 0;
+  if (replacements.length === 0) return void 0;
 
   const transformedHtml = applyReplacements(html, replacements);
   const imports = assets.map(asset => `import ${asset.variable} from ${JSON.stringify(asset.specifier)};\n`);
   return {
     imports,
-    templateExpression: createTemplateExpression(transformedHtml, assets),
+    templateExpression: assets.length === 0 ? JSON.stringify(transformedHtml) : createTemplateExpression(transformedHtml, assets),
   };
 }
 

--- a/packages-tooling/vite-plugin/src/template-assets.ts
+++ b/packages-tooling/vite-plugin/src/template-assets.ts
@@ -1,6 +1,4 @@
-import { statSync } from 'fs';
-import type { IHtmlTransformResult } from '@aurelia/plugin-conventions';
-import { dirname, resolve } from 'path';
+import type { IFileUnit, IFileUnitHost, IHtmlTransformResult } from '@aurelia/plugin-conventions';
 import { parseFragment } from 'parse5';
 import type { DefaultTreeAdapterMap, Token } from 'parse5';
 
@@ -63,7 +61,8 @@ interface AssetToken {
 
 export function transformTemplateAssetUrls(
   html: string,
-  htmlId: string,
+  unit: IFileUnit,
+  host: IFileUnitHost,
   warn: (message: string) => void,
 ): IHtmlTransformResult | undefined {
   const replacements: Replacement[] = [];
@@ -90,7 +89,7 @@ export function transformTemplateAssetUrls(
       const loc = node.sourceCodeLocation?.attrs?.[name];
       if (value == null || loc == null) return;
 
-      const token = createAssetToken(value, htmlId, assets, fileExistsCache, warn);
+      const token = createAssetToken(value, unit, host, assets, fileExistsCache, warn);
       if (token == null) return;
       const valueLocation = getAttributeValueLocation(html, loc);
       if (valueLocation == null) return;
@@ -101,7 +100,7 @@ export function transformTemplateAssetUrls(
       const value = attrs.get(name);
       const loc = node.sourceCodeLocation?.attrs?.[name];
       if (value == null || loc == null) return;
-      replaceSrcset(value, loc, html, htmlId, replacements, assets, fileExistsCache, warn);
+      replaceSrcset(value, loc, html, unit, host, replacements, assets, fileExistsCache, warn);
     });
   });
 
@@ -149,7 +148,8 @@ function replaceSrcset(
   value: string,
   attrLocation: AttributeLocation,
   html: string,
-  htmlId: string,
+  unit: IFileUnit,
+  host: IFileUnitHost,
   replacements: Replacement[],
   assets: AssetToken[],
   fileExistsCache: Map<string, boolean>,
@@ -160,7 +160,7 @@ function replaceSrcset(
 
   let changed = false;
   const srcset = value.replace(/(^|,)(\s*)([^,\s]+)([^,]*)/g, (match, separator: string, whitespace: string, url: string, descriptor: string) => {
-    const token = createAssetToken(url, htmlId, assets, fileExistsCache, warn);
+    const token = createAssetToken(url, unit, host, assets, fileExistsCache, warn);
     if (token == null) return match;
     changed = true;
     return `${separator}${whitespace}${token.token}${descriptor}`;
@@ -173,7 +173,8 @@ function replaceSrcset(
 
 function createAssetToken(
   specifier: string,
-  htmlId: string,
+  unit: IFileUnit,
+  host: IFileUnitHost,
   assets: AssetToken[],
   fileExistsCache: Map<string, boolean>,
   warn: (message: string) => void,
@@ -181,7 +182,7 @@ function createAssetToken(
   const importSpecifier = specifier.startsWith('.') ? specifier : `./${specifier}`;
   const existingAsset = assets.find(asset => asset.specifier === importSpecifier);
   if (existingAsset != null) return existingAsset;
-  if (!shouldBundleAsset(specifier, htmlId, fileExistsCache, warn)) return void 0;
+  if (!shouldBundleAsset(specifier, unit, host, fileExistsCache, warn)) return void 0;
 
   const token = `__au_vite_asset_${assets.length}__`;
   const asset = {
@@ -195,7 +196,8 @@ function createAssetToken(
 
 function shouldBundleAsset(
   specifier: string,
-  htmlId: string,
+  unit: IFileUnit,
+  host: IFileUnitHost,
   fileExistsCache: Map<string, boolean>,
   warn: (message: string) => void,
 ): boolean {
@@ -213,19 +215,14 @@ function shouldBundleAsset(
   const filePath = getFilePath(specifier);
   if (filePath == null) return false;
 
-  const resolved = resolve(dirname(htmlId), filePath);
-  const cached = fileExistsCache.get(resolved);
+  const relativePath = filePath.startsWith('.') ? filePath : `./${filePath}`;
+  const cached = fileExistsCache.get(relativePath);
   if (cached != null) return cached;
 
-  let exists = false;
-  try {
-    exists = statSync(resolved).isFile();
-  } catch {
-    // The unresolved URL remains in the template for backwards compatibility.
-  }
-  fileExistsCache.set(resolved, exists);
+  const exists = host.fileExists(unit, relativePath);
+  fileExistsCache.set(relativePath, exists);
   if (!exists) {
-    warn(`Unable to resolve template asset ${JSON.stringify(specifier)} referenced by ${JSON.stringify(htmlId)}. The URL will be left unchanged.`);
+    warn(`Unable to resolve template asset ${JSON.stringify(specifier)} referenced by ${JSON.stringify(unit.path)}. The URL will be left unchanged.`);
   }
   return exists;
 }

--- a/packages-tooling/vite-plugin/src/template-assets.ts
+++ b/packages-tooling/vite-plugin/src/template-assets.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'fs';
-import type { IHtmlTemplateTransformResult } from '@aurelia/plugin-conventions';
+import type { IHtmlTransformResult } from '@aurelia/plugin-conventions';
 import { dirname, resolve } from 'path';
 import { parseFragment } from 'parse5';
 import type { DefaultTreeAdapterMap, Token } from 'parse5';
@@ -29,7 +29,7 @@ interface AssetToken {
   specifier: string;
 }
 
-export function transformTemplateAssetUrls(html: string, htmlId: string): IHtmlTemplateTransformResult | undefined {
+export function transformTemplateAssetUrls(html: string, htmlId: string): IHtmlTransformResult | undefined {
   const replacements: Replacement[] = [];
   const assets: AssetToken[] = [];
   const tree = parseFragment(html, { sourceCodeLocationInfo: true });

--- a/packages/__e2e__/17-vite-template-assets/index.html
+++ b/packages/__e2e__/17-vite-template-assets/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Aurelia Vite template assets test</title>
+  </head>
+  <body>
+    <app></app>
+    <script type="module" src="/src/index.ts"></script>
+  </body>
+</html>

--- a/packages/__e2e__/17-vite-template-assets/package.json
+++ b/packages/__e2e__/17-vite-template-assets/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@__e2e__/17-vite-template-assets",
+  "license": "MIT",
+  "private": true,
+  "version": "2.0.0-rc.2",
+  "port": 9017,
+  "scripts": {
+    "build": "vite build",
+    "test:e2e": "npm run build && playwright test",
+    "test": "npm run test:e2e"
+  },
+  "dependencies": {
+    "aurelia": "2.0.0-rc.2"
+  },
+  "devDependencies": {
+    "@aurelia/vite-plugin": "2.0.0-rc.2",
+    "@playwright/test": "1.62.1",
+    "playwright": "1.62.1",
+    "@types/node": "22.20.1",
+    "vite": "^7.0.2"
+  },
+  "engines": {
+    "node": ">=22.22.2"
+  }
+}

--- a/packages/__e2e__/17-vite-template-assets/playwright.config.js
+++ b/packages/__e2e__/17-vite-template-assets/playwright.config.js
@@ -1,0 +1,6 @@
+// @ts-check
+module.exports = {
+  ...require('../playwright-util')(require('./package.json')),
+  globalSetup: require.resolve('./playwright/global-setup'),
+  workers: 1,
+};

--- a/packages/__e2e__/17-vite-template-assets/playwright/global-setup.js
+++ b/packages/__e2e__/17-vite-template-assets/playwright/global-setup.js
@@ -1,0 +1,19 @@
+// @ts-check
+const pkg = require('../package.json');
+
+module.exports = async function globalSetup() {
+  const { preview } = await import('vite');
+  const server = await preview({
+    preview: {
+      host: '127.0.0.1',
+      port: pkg.port,
+      strictPort: true,
+    },
+  });
+
+  return async () => {
+    await new Promise((resolve, reject) => {
+      server.httpServer.close(error => error == null ? resolve(undefined) : reject(error));
+    });
+  };
+};

--- a/packages/__e2e__/17-vite-template-assets/playwright/production.spec.ts
+++ b/packages/__e2e__/17-vite-template-assets/playwright/production.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test';
+
+test('emits and serves an asset referenced from a conventional template', async function ({ page, baseURL }) {
+  await page.goto(baseURL!, { waitUntil: 'networkidle' });
+
+  const asset = page.locator('#template-asset');
+  await expect(asset).toBeVisible();
+  await expect(asset).toHaveJSProperty('complete', true);
+  expect(await asset.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBeGreaterThan(0);
+  await expect(asset).toHaveAttribute('src', /\/assets\/aurelia-logo-[\w-]+\.svg$/);
+});

--- a/packages/__e2e__/17-vite-template-assets/playwright/production.spec.ts
+++ b/packages/__e2e__/17-vite-template-assets/playwright/production.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '@playwright/test';
+import { build, createServer } from 'vite';
+import aurelia from '@aurelia/vite-plugin';
 
 test('rewrites template assets and preserves ignored or missing references', async function ({ page, baseURL }) {
   await page.goto(baseURL!, { waitUntil: 'networkidle' });
@@ -19,4 +21,52 @@ test('rewrites template assets and preserves ignored or missing references', asy
   await expect(missingAsset).toHaveJSProperty('complete', true);
   await expect(missingAsset).toHaveAttribute('src', './missing-logo.svg');
   expect(await missingAsset.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBe(0);
+});
+
+test('fails a production build when missing template assets are errors', async function () {
+  await expect(build({
+    root: process.cwd(),
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      assetsInlineLimit: 0,
+      write: false,
+    },
+    plugins: [aurelia({ transformTemplateAssets: 'error' })],
+  })).rejects.toThrow(/Unable to resolve template asset "\.\/missing-logo\.svg"/);
+});
+
+test('rewrites template assets during development', async function ({ page }) {
+  const server = await createServer({
+    root: process.cwd(),
+    configFile: false,
+    logLevel: 'silent',
+    server: {
+      host: '127.0.0.1',
+      port: 0,
+    },
+    plugins: [aurelia()],
+  });
+
+  try {
+    await server.listen();
+    const address = server.httpServer?.address();
+    if (address == null || typeof address === 'string') {
+      throw new Error('Unable to determine the Vite development server address.');
+    }
+
+    await page.goto(`http://127.0.0.1:${address.port}`, { waitUntil: 'networkidle' });
+
+    const asset = page.locator('#template-asset');
+    await expect(asset).not.toHaveAttribute('src', './assets/aurelia-logo.svg');
+    expect(await asset.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBeGreaterThan(0);
+
+    const ignoredAsset = page.locator('#ignored-template-asset');
+    await expect(ignoredAsset).not.toHaveAttribute('au-vite-ignore');
+    await expect(ignoredAsset).toHaveAttribute('src', './ignored-logo.svg');
+
+    await expect(page.locator('#missing-template-asset')).toHaveAttribute('src', './missing-logo.svg');
+  } finally {
+    await server.close();
+  }
 });

--- a/packages/__e2e__/17-vite-template-assets/playwright/production.spec.ts
+++ b/packages/__e2e__/17-vite-template-assets/playwright/production.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('emits and serves an asset referenced from a conventional template', async function ({ page, baseURL }) {
+test('rewrites template assets and strips ignored asset markers', async function ({ page, baseURL }) {
   await page.goto(baseURL!, { waitUntil: 'networkidle' });
 
   const asset = page.locator('#template-asset');
@@ -8,4 +8,10 @@ test('emits and serves an asset referenced from a conventional template', async 
   await expect(asset).toHaveJSProperty('complete', true);
   expect(await asset.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBeGreaterThan(0);
   await expect(asset).toHaveAttribute('src', /\/assets\/aurelia-logo-[\w-]+\.svg$/);
+
+  const ignoredAsset = page.locator('#ignored-template-asset');
+  await expect(ignoredAsset).toBeVisible();
+  await expect(ignoredAsset).not.toHaveAttribute('au-vite-ignore');
+  await expect(ignoredAsset).toHaveAttribute('src', './ignored-logo.svg');
+  expect(await ignoredAsset.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBeGreaterThan(0);
 });

--- a/packages/__e2e__/17-vite-template-assets/playwright/production.spec.ts
+++ b/packages/__e2e__/17-vite-template-assets/playwright/production.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('rewrites template assets and strips ignored asset markers', async function ({ page, baseURL }) {
+test('rewrites template assets and preserves ignored or missing references', async function ({ page, baseURL }) {
   await page.goto(baseURL!, { waitUntil: 'networkidle' });
 
   const asset = page.locator('#template-asset');
@@ -14,4 +14,9 @@ test('rewrites template assets and strips ignored asset markers', async function
   await expect(ignoredAsset).not.toHaveAttribute('au-vite-ignore');
   await expect(ignoredAsset).toHaveAttribute('src', './ignored-logo.svg');
   expect(await ignoredAsset.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBeGreaterThan(0);
+
+  const missingAsset = page.locator('#missing-template-asset');
+  await expect(missingAsset).toHaveJSProperty('complete', true);
+  await expect(missingAsset).toHaveAttribute('src', './missing-logo.svg');
+  expect(await missingAsset.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBe(0);
 });

--- a/packages/__e2e__/17-vite-template-assets/public/ignored-logo.svg
+++ b/packages/__e2e__/17-vite-template-assets/public/ignored-logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#7c3aed"/>
+</svg>

--- a/packages/__e2e__/17-vite-template-assets/src/app.html
+++ b/packages/__e2e__/17-vite-template-assets/src/app.html
@@ -1,0 +1,4 @@
+<main>
+  <h1>Vite template asset</h1>
+  <img id="template-asset" src="./assets/aurelia-logo.svg" alt="Aurelia logo">
+</main>

--- a/packages/__e2e__/17-vite-template-assets/src/app.html
+++ b/packages/__e2e__/17-vite-template-assets/src/app.html
@@ -1,4 +1,5 @@
 <main>
   <h1>Vite template asset</h1>
   <img id="template-asset" src="./assets/aurelia-logo.svg" alt="Aurelia logo">
+  <img id="ignored-template-asset" au-vite-ignore src="./ignored-logo.svg" alt="Ignored Aurelia logo">
 </main>

--- a/packages/__e2e__/17-vite-template-assets/src/app.html
+++ b/packages/__e2e__/17-vite-template-assets/src/app.html
@@ -2,4 +2,5 @@
   <h1>Vite template asset</h1>
   <img id="template-asset" src="./assets/aurelia-logo.svg" alt="Aurelia logo">
   <img id="ignored-template-asset" au-vite-ignore src="./ignored-logo.svg" alt="Ignored Aurelia logo">
+  <img id="missing-template-asset" src="./missing-logo.svg" alt="Missing logo">
 </main>

--- a/packages/__e2e__/17-vite-template-assets/src/app.ts
+++ b/packages/__e2e__/17-vite-template-assets/src/app.ts
@@ -1,0 +1,1 @@
+export class App {}

--- a/packages/__e2e__/17-vite-template-assets/src/assets/aurelia-logo.svg
+++ b/packages/__e2e__/17-vite-template-assets/src/assets/aurelia-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+  <circle cx="60" cy="60" r="54" fill="#ed2b88"/>
+  <path d="M34 78 60 28l26 50H72L60 54 48 78Z" fill="#fff"/>
+</svg>

--- a/packages/__e2e__/17-vite-template-assets/src/ignored-logo.svg
+++ b/packages/__e2e__/17-vite-template-assets/src/ignored-logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#7c3aed"/>
+</svg>

--- a/packages/__e2e__/17-vite-template-assets/src/index.ts
+++ b/packages/__e2e__/17-vite-template-assets/src/index.ts
@@ -1,0 +1,4 @@
+import Aurelia from 'aurelia';
+import { App } from './app';
+
+void Aurelia.app(App).start();

--- a/packages/__e2e__/17-vite-template-assets/test-results/.last-run.json
+++ b/packages/__e2e__/17-vite-template-assets/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/packages/__e2e__/17-vite-template-assets/tsconfig.json
+++ b/packages/__e2e__/17-vite-template-assets/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig-build.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "lib": ["esnext", "dom"],
+    "types": ["node", "vite/client"],
+    "useDefineForClassFields": false
+  },
+  "include": ["src", "playwright", "../playwright-coverage.ts"]
+}

--- a/packages/__e2e__/17-vite-template-assets/vite.config.mjs
+++ b/packages/__e2e__/17-vite-template-assets/vite.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import aurelia from '@aurelia/vite-plugin';
+
+export default defineConfig({
+  build: {
+    assetsInlineLimit: 0,
+    target: 'es2022',
+  },
+  plugins: [
+    aurelia(),
+  ],
+});


### PR DESCRIPTION
### 🎫 Issues

As per requested in #2371 and the attempt in #2430 , this PR provides a more compatible version based on the recent changes in the plugin convetion package.
The goal remains the same: relative asset bundling just works, a warning is emitted when the asset is missing, and the behavior can be opted out.

Also adds:
- align support for elements that vite supports, like the follow map
    | Element | Asset attributes |
    |---|---|
    | `<audio>` | `src` |
    | `<embed>` | `src` |
    | `<img>` | `src`, `srcset` |
    | `<image>` (SVG) | `href`, `xlink:href` |
    | `<input>` | `src` |
    | `<link>` | `href`, `imagesrcset` |
    | `<meta>` | `content`¹ |
    | `<object>` | `data` |
    | `<source>` | `src`, `srcset` |
    | `<track>` | `src` |
    | `<use>` (SVG) | `href`, `xlink:href` |
    | `<video>` | `src`, `poster` |
    
    ¹ `<meta content>` is treated as an asset only for Vite’s recognized image, audio, and video metadata names and properties, such as `twitter:image`, `og:image`, `og:audio`, and `og:video`.
    
    Module `<script src>` entries are handled separately by Vite’s HTML entry pipeline, so they are not part of this template-asset source set.
- ability to optout relative asset bundling via `templateAssets: false`
- ability to exclude a particular element only via `au-vite-ignore`

## API changes

### `templateAssets`

The Aurelia Vite plugin now processes static relative asset URLs in HTML templates during both development and production.

Template asset behavior is configured using the `templateAssets` option:

```ts
interface TemplateAssetOptions {
  onMissing?: 'ignore' | 'warn' | 'error';
}

interface AureliaPluginOptions {
  templateAssets?: boolean | TemplateAssetOptions;
}
```

Value | Behavior
-- | --
`true` | Process relative template assets. Missing assets produce a warning and remain unchanged. This is the default.
`{ onMissing: 'ignore' }` | Process valid assets and silently preserve unresolved URLs.
`{ onMissing: 'warn' }` | Process valid assets and warn when a relative asset cannot be resolved.
`{ onMissing: 'error' }` | Stop the Vite transform when a relative asset cannot be resolved.
`false` | Disable template asset processing and leave all template asset URLs unchanged.

Example usage:

```ts
import { defineConfig } from 'vite';
import aurelia from '@aurelia/vite-plugin';

export default defineConfig({
  plugins: [
    aurelia({
      templateAssets: {
        onMissing: 'error',
      },
    }),
  ],
});
```

### Per-element opt-out

Use `au-vite-ignore` to leave asset URLs on an individual element unchanged:

```html
<img au-vite-ignore src="./logo.svg" alt="Logo">
```

The `au-vite-ignore` marker is removed from the compiled template and bypasses missing-asset warnings and errors.

### Asset resolution

Detected relative asset URLs are managed by Vite. Final URLs will follow Vite's configuration (hashing, `base`, `assetsDir`, transformation etc...)

Asset existence checks use `IFileUnitHost`. Only disk-backed assets are currently supported; virtual assets provided exclusively by Vite plugins are treated as unresolved relative assets.

## 👩‍💻 Reviewer Notes

@Vheissu @3cp 
@fkleuver can you pls help review and see what needs to be tweaked here + aligned in the ls?

## 📑 Test Plan

- all existing tests pass
- new e2e for bundling/missing/ignoring assets

Supersedes & closes #2430
Closes #2392
Closes #2371

cc @rmja