### PR TITLE
fix(runtime-html): preserve array observation in content interpolation

### DIFF
--- a/.changeset/fresh-array-content.md
+++ b/.changeset/fresh-array-content.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/runtime-html": patch
+---
+
+Text interpolations now continue to update when an expression reevaluates to the same array. This includes later array edits and edits made before a queued update runs.

--- a/packages/__tests__/src/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/interpolation.spec.ts
@@ -14,7 +14,7 @@ import {
   IPlatform,
   ValueConverter,
 } from '@aurelia/runtime-html';
-import { tasksSettled } from '@aurelia/runtime';
+import { type ArrayObserver, tasksSettled } from '@aurelia/runtime';
 import { resolve } from '@aurelia/kernel';
 
 type CaseType = {
@@ -520,6 +520,126 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
         );
       });
     });
+  });
+
+  it('keeps observing tags after refreshing a project with the same tag list', async function () {
+    const { component, appHost, tearDown } = await createFixture(
+      '<span title="${project.tags}">${project.tags}</span>',
+      class {
+        public project = { name: 'Launch', tags: ['a'] };
+      },
+    ).started;
+    const span = appHost.querySelector('span');
+
+    try {
+      component.project.tags.push('b');
+      await tasksSettled();
+      assert.strictEqual(span.textContent, 'a,b');
+
+      // Saving another project field replaces the record but retains its tag list.
+      component.project = { ...component.project, name: 'Release' };
+      await tasksSettled();
+      assert.strictEqual(span.textContent, 'a,b');
+
+      component.project.tags.push('c');
+      await tasksSettled();
+      assert.strictEqual(span.title, 'a,b,c', 'attribute interpolation observes the tag list');
+      assert.strictEqual(span.textContent, 'a,b,c', 'content interpolation still observes the tag list');
+    } finally {
+      await tearDown();
+    }
+  });
+
+  for (const collectionFirst of [false, true]) {
+    it(`renders tag edits queued ${collectionFirst ? 'before' : 'after'} a project refresh`, async function () {
+      const { component, assertText, tearDown } = await createFixture(
+        '${project.tags}',
+        class {
+          public project = { name: 'Launch', tags: ['a'] };
+        },
+      ).started;
+
+      try {
+        // Both notifications share one queued evaluation. Its result is still the same array.
+        if (collectionFirst) {
+          component.project.tags.push('b');
+          component.project = { ...component.project, name: 'Release' };
+        } else {
+          component.project = { ...component.project, name: 'Release' };
+          component.project.tags.push('b');
+        }
+        assertText('a');
+        await tasksSettled();
+        assertText('a,b');
+
+        component.project.tags.push('c');
+        await tasksSettled();
+        assertText('a,b,c');
+      } finally {
+        await tearDown();
+      }
+    });
+  }
+
+  it('releases replaced tag lists and observes the current list when a cached view rebinds', async function () {
+    const fixture = await createFixture(
+      '<span if.bind="show">${project.tags}</span>',
+      class {
+        public show = true;
+        public project = { name: 'Launch', tags: ['a'] as string[] | null };
+      },
+    ).started;
+    const { component, observerLocator, assertText } = fixture;
+    const originalTags = component.project.tags;
+    const originalObserver = observerLocator.getArrayObserver(originalTags) as ArrayObserver;
+    const replacementTags = ['b'];
+    const replacementObserver = observerLocator.getArrayObserver(replacementTags) as ArrayObserver;
+
+    try {
+      component.project = { ...component.project, name: 'Release' };
+      await tasksSettled();
+      assert.strictEqual(originalObserver.subs.count, 1, 'the refreshed result is observed once');
+
+      component.project.tags = replacementTags;
+      await tasksSettled();
+      assertText('b');
+      assert.strictEqual(originalObserver.subs.count, 0, 'the old list is detached');
+      assert.strictEqual(replacementObserver.subs.count, 1, 'the replacement list is observed');
+
+      component.project.tags = null;
+      await tasksSettled();
+      assertText('');
+      assert.strictEqual(replacementObserver.subs.count, 0, 'a non-array result detaches the list');
+
+      component.project.tags = replacementTags;
+      await tasksSettled();
+      assertText('b');
+
+      // Hide the view while its project refresh is still queued. It must remain detached after the queue drains.
+      component.project = { ...component.project, name: 'Archived' };
+      component.show = false;
+      await tasksSettled();
+      assertText('');
+      assert.strictEqual(replacementObserver.subs.count, 0, 'unbinding releases the list');
+      replacementTags.push('c');
+      await tasksSettled();
+      assertText('');
+
+      component.show = true;
+      await tasksSettled();
+      assertText('b,c');
+      assert.strictEqual(replacementObserver.subs.count, 1, 'rebind creates one subscription');
+
+      component.project = { ...component.project, name: 'Reopened' };
+      await tasksSettled();
+      replacementTags.push('a');
+      await tasksSettled();
+      assertText('b,c,a');
+    } finally {
+      await fixture.tearDown();
+    }
+    assert.strictEqual(originalObserver.subs.count, 0);
+    assert.strictEqual(replacementObserver.subs.count, 0, 'application teardown releases the list');
   });
 
   it('works with strict mode', async function () {

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -112,7 +112,9 @@ export class ContentBinding implements IBinding, ISubscriber, ICollectionSubscri
       const newValue = astEvaluate(this.ast, this._scope!, this, (this.mode & toView) > 0 ? this : null);
       this.obs.clear();
 
-      if (newValue !== this._value) {
+      // Reconnect array results even when their identity is unchanged. This update also
+      // covers array mutations that arrived while the property change was queued.
+      if (newValue !== this._value || isArray(newValue)) {
         if (isArray(newValue)) {
           this.observeCollection(newValue);
         }


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

Text interpolations could stop updating when an expression reevaluated to the same array, such as after refreshing a parent object.

## 💁 Your Solution

Keep array results observed and refresh their rendered text, including edits made before a queued update runs.

## 📑 Test Plan

- Parent-object refresh that retains the same array.
- Array edits queued before or after the refresh.
- Array replacement and transitions to/from `null`.
- Unbinding with pending updates, cached-view rebinding, and teardown cleanup.

## 📦 Changeset

- [x] Added a changeset