### PR TITLE
fix(runtime): support null-prototype records in proxy observation

### DIFF
--- a/.changeset/null-prototype-observation.md
+++ b/.changeset/null-prototype-observation.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/runtime": patch
+---
+
+Computed getters can now read objects created with `Object.create(null)`, including Router parameter snapshots. These objects no longer cause proxy observation to throw when checking `@nowrap` metadata.

--- a/packages/__tests__/src/2-runtime/proxy-observable.spec.ts
+++ b/packages/__tests__/src/2-runtime/proxy-observable.spec.ts
@@ -14,6 +14,8 @@ describe('2-runtime/proxy-observable.spec.ts', function () {
     // can do
     { title: 'proxy', v: new Proxy({}, {}), canWrap: true },
     { title: 'normal object', v: {}, canWrap: true },
+    { title: 'null-prototype object', v: Object.create(null), canWrap: true },
+    { title: 'frozen null-prototype object', v: Object.freeze(Object.create(null)), canWrap: true },
     { title: 'Array', v: [], canWrap: true },
     { title: 'Array subclass', v: new class extends Array { }(), canWrap: true },
     { title: 'Map', v: new Map(), canWrap: true },
@@ -25,6 +27,7 @@ describe('2-runtime/proxy-observable.spec.ts', function () {
       const wrapped = ProxyObservable.wrap(v);
       if (canWrap) {
         assert.notStrictEqual(wrapped, v);
+        assert.strictEqual(ProxyObservable.unwrap(wrapped), v);
       } else {
         assert.strictEqual(wrapped, v);
       }

--- a/packages/__tests__/src/3-runtime-html/computed-observer.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/computed-observer.spec.ts
@@ -11,6 +11,68 @@ import {
 import { bindable, BindingMode, customElement } from '@aurelia/runtime-html';
 
 describe('3-runtime-html/computed-observer.spec.ts', function () {
+  it('observes a null-prototype dictionary through a computed getter across replacement and rebind', async function () {
+    let evaluations = 0;
+    const fixture = await createFixture(
+      '<span if.bind="show">${total}</span>',
+      class {
+        public show = true;
+        public counts: Record<string, number> = Object.assign(Object.create(null), { a: 1, b: 2 });
+
+        public get total(): number {
+          evaluations++;
+          return this.counts.a + this.counts.b;
+        }
+      },
+    ).started;
+    const { component, assertText } = fixture;
+    const original = component.counts;
+
+    try {
+      assertText('3');
+      original.a = 4;
+      await tasksSettled();
+      assertText('6');
+
+      component.counts = Object.assign(Object.create(null), { a: 10, b: 20 });
+      await tasksSettled();
+      assertText('30');
+
+      const afterReplacement = evaluations;
+      original.a = 7;
+      await tasksSettled();
+      assert.strictEqual(evaluations, afterReplacement, 'the replaced dictionary is no longer observed');
+
+      component.counts.b = 25;
+      await tasksSettled();
+      assertText('35');
+
+      // Unbind with a dictionary update still queued, then edit the detached source.
+      component.counts.a = 11;
+      component.show = false;
+      await tasksSettled();
+      assertText('');
+      const afterUnbind = evaluations;
+      component.counts.a = 12;
+      await tasksSettled();
+      assert.strictEqual(evaluations, afterUnbind, 'the inactive getter releases its dictionary dependencies');
+
+      component.show = true;
+      await tasksSettled();
+      assertText('37');
+      component.counts.b = 30;
+      await tasksSettled();
+      assertText('42');
+    } finally {
+      await fixture.tearDown();
+    }
+
+    const afterTeardown = evaluations;
+    component.counts.a = 13;
+    await tasksSettled();
+    assert.strictEqual(evaluations, afterTeardown, 'application teardown releases the dictionary dependencies');
+  });
+
   interface IComputedObserverTestCase<T extends IApp = IApp> {
     title: string;
     template: string;

--- a/packages/__tests__/src/router/route-parameters.spec.ts
+++ b/packages/__tests__/src/router/route-parameters.spec.ts
@@ -7,6 +7,45 @@ import { start } from './_shared/create-fixture.js';
 
 describe('router/route-parameters.spec.ts', function () {
   describe('RouteContext.getRouteParameters', function () {
+    it('allows a computed label to read a route parameter snapshot', async function () {
+      @customElement({ name: 'item-details', template: '<div>${label}</div>' })
+      class ItemDetails {
+        public readonly params = resolve(IRouteContext)
+          .getRouteParameters<{ id: string; tag: readonly string[] }, 'child-first'>({ includeQueryParams: true });
+
+        // Derived display values read the same snapshot that direct template bindings can use.
+        public get label(): string {
+          return `Item ${this.params.id}: ${this.params.tag.join(',')}`;
+        }
+      }
+
+      @customElement({ name: 'empty-view', template: '' })
+      class EmptyView { }
+
+      @route({ routes: [
+        { path: '', component: EmptyView },
+        { path: 'items/:id', component: ItemDetails },
+      ] })
+      @customElement({ name: 'app-root', template: '<au-viewport></au-viewport>' })
+      class AppRoot { }
+
+      const { host, au, container } = await start({ appRoot: AppRoot });
+      const router = container.get(IRouter);
+      try {
+        // Repeated query values are frozen arrays; reading the snapshot must preserve their identity.
+        await router.load('items/a?tag=x&tag=y');
+        assert.html.textContent(host, 'Item a: x,y');
+
+        await router.load('');
+        assert.html.textContent(host, '');
+
+        await router.load('items/b?tag=y&tag=z');
+        assert.html.textContent(host, 'Item b: y,z');
+      } finally {
+        await au.stop(true);
+      }
+    });
+
     it('aggregates parameters from ancestor contexts', async function () {
       @customElement({ name: 'details-view', template: `<div>company:\${params.companyId};project:\${params.projectId};user:\${params.userId};detail:\${params.detailId}</div>` })
       class DetailsView {

--- a/packages/runtime/src/proxy-observation.ts
+++ b/packages/runtime/src/proxy-observation.ts
@@ -23,8 +23,8 @@ export const nowrapPropKey = '__au_nw';
 function canWrap(obj: unknown): obj is object {
   switch (toStringTag.call(obj)) {
     case '[object Object]':
-      // enable inheritance decoration
-      return ((obj as object).constructor as IIndexable<() => unknown>)[nowrapClassKey] !== true;
+      // Null-prototype records have no constructor; ordinary instances retain inherited @nowrap metadata.
+      return ((obj as object).constructor as IIndexable<() => unknown> | undefined)?.[nowrapClassKey] !== true;
     case '[object Array]':
     case '[object Map]':
     case '[object Set]':
@@ -74,7 +74,7 @@ function doNotCollect(object: object, key: PropertyKey): boolean {
     // limit to string first
     // symbol can be added later
     // looking up from the constructor means inheritance is supported
-    || (object.constructor as IIndexable<() => unknown>)[`${nowrapPropKey}_${rtSafeString(key)}__`] === true
+    || (object.constructor as IIndexable<() => unknown> | undefined)?.[`${nowrapPropKey}_${rtSafeString(key)}__`] === true
   ) {
     return true;
   }


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

Computed getters could throw when reading null-prototype objects, including parameter snapshots returned by `IRouteContext.getRouteParameters()`.

## 💁 Your Solution

Allow missing constructors when checking `@nowrap` metadata, preserving inherited markers and frozen-property handling.

## 📑 Test Plan

- Routed computed getters reading parameter snapshots and frozen query-value arrays.
- Mutable dictionary updates and replacement.
- Queued unbinding, cached-view rebinding, and teardown cleanup.
- Wrap/unwrap identity and existing `@nowrap` inheritance behavior.

## 📦 Changeset

- [x] Added a changeset